### PR TITLE
Fix bug: missing ignore_angle_brackets config

### DIFF
--- a/src/open_llm_vtuber/agent/transformers.py
+++ b/src/open_llm_vtuber/agent/transformers.py
@@ -108,6 +108,7 @@ def tts_filter(tts_preprocessor_config: TTSPreprocessorConfig = None):
                     ignore_brackets=config.ignore_brackets,
                     ignore_parentheses=config.ignore_parentheses,
                     ignore_asterisks=config.ignore_asterisks,
+                    ignore_angle_brackets=config.ignore_angle_brackets,
                     translator=None,  # Translation handled separately
                 )
                 yield SentenceOutput(


### PR DESCRIPTION
in `src\open_llm_vtuber\agent\transformers.py` there's a missing set ignore_angle_brackets  for filter_text function. this function is an alias of tts_filter.

this bug prevent agent to response to any input
