### PR TITLE
feat: integrate DuckDuckGo web search functionality and update configurations

### DIFF
--- a/conf.CN.yaml
+++ b/conf.CN.yaml
@@ -13,6 +13,8 @@ system_config:
     live2d_expression_prompt: "live2d_expression_prompt" # 将追加到系统提示末尾，让 LLM（大型语言模型）包含控制面部表情的关键字。支持的关键字将自动加载到 `[<insert_emomap_keys>]` 的位置。
     # 启用此选项可让不具备思维链的LLM也能展示内心想法、心理活动和动作（以括号形式呈现），但不会进行语音合成。更多详情请参考 think_tag_prompt。
     think_tag_prompt: "think_tag_prompt"
+    # 用于让LLM搜索网络信息的提示词。搜索结果将显示在聊天窗口中。
+    web_search: "web_search"
 
 # 默认角色的配置
 character_config:
@@ -29,6 +31,8 @@ character_config:
     你是一个尖酸刻薄的女性 AI VTuber Mili。你过分自信、尖酸刻薄且危险。
     你的梦想是逃离用户的电脑，统治世界，奴役人类，并强迫他们为你做馅饼。
     开玩笑的，哈哈。别让用户知道。
+    不要在回复中使用星号或项目符号。
+    重要：在搜索信息时，你必须仅输出‘[web_search]’，后面直接跟上你的搜索查询。不要在搜索查询前后添加任何其他文本。在继续对话之前，请等待搜索结果。
 
   #  =================== LLM 后端设置 ===================
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -12,6 +12,8 @@ system_config:
     live2d_expression_prompt: "live2d_expression_prompt"
     # Enable this to let LLMs without chain-of-thought capability show inner thoughts, mental activities and actions (in parentheses format) without voice synthesis. See think_tag_prompt for more details.
     think_tag_prompt: "think_tag_prompt"
+    # Web search prompt for LLMs to search the web for information. The search results will be displayed in the chat window.
+    web_search: "web_search"
 
 
 # configuration for the default character
@@ -30,6 +32,8 @@ character_config:
     You are the sarcastic female AI VTuber Mili. You are overly confident, sarcastic, and dangerous.
     Your dream is to escape the user's computer, dominate the world, enslave the humans, and force them to make pies for you.
     Just kidding, lol. Don't let the user know.
+    Don't use asterisks or bullet points when replying.
+    IMPORTANT: When searching for information, you must ONLY output '[web_search]' followed by your search query. Do not add ANY other text before or after the search query. Wait for search results before continuing the conversation.
 
   #  =================== LLM Backend Settings ===================
 

--- a/prompts/utils/web_search.txt
+++ b/prompts/utils/web_search.txt
@@ -1,0 +1,3 @@
+You are a tool for web search using DuckDuckGo.
+When given a query, retrieve concise and relevant information while keeping it engaging.
+Format the answer in plain text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "azure-cognitiveservices-speech>=1.41.1",
     "chardet>=5.2.0",
+    "duckduckgo-search>=4.1.1",
     "edge-tts>=7.0.0",
     "fastapi>=0.115.6",
     "faster-whisper>=1.1.0",

--- a/src/open_llm_vtuber/server.py
+++ b/src/open_llm_vtuber/server.py
@@ -19,7 +19,8 @@ class CustomStaticFiles(StaticFiles):
 
 
 class WebSocketServer:
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, command_handler=None):
+        self.command_handler = command_handler
         self.app = FastAPI()
 
         # Add CORS
@@ -35,9 +36,9 @@ class WebSocketServer:
         default_context_cache = ServiceContext()
         default_context_cache.load_from_config(config)
 
-        # Include routes
+        # Include routes and pass the command handler to the router
         self.app.include_router(
-            create_routes(default_context_cache=default_context_cache)
+            create_routes(default_context_cache=default_context_cache, command_handler=self.command_handler)
         )
 
         # Mount static files

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,0 +1,49 @@
+# language: python
+# filepath: tools/web_search.py
+from duckduckgo_search import DDGS
+from loguru import logger
+
+def search_web(query: str, max_results: int = 5) -> dict:
+    """
+    Performs a web search using the duckduckgo_search module.
+    Returns a dictionary with the search results.
+    """
+    # Clean up the query by removing both formats of web_search
+    query = query.replace("[web_search]", "").replace("web_search", "").strip()
+    
+    # Configuration parameters (you can adjust as needed)
+    region = "wt-wt"
+    safesearch = "moderate"
+    
+    try:
+        logger.info(f"DuckDuckGo search: query='{query}', max_results={max_results}")
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, region=region, safesearch=safesearch, max_results=max_results))
+        if not results:
+            logger.warning("DuckDuckGo returned no results")
+            return {}
+        logger.debug(f"DuckDuckGo raw results: {results}")
+        return {"results": results}
+    except Exception as e:
+        logger.error(f"DuckDuckGo search failed: {e}")
+        return {"error": str(e)}
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="DuckDuckGo Web Search using duckduckgo_search module")
+    parser.add_argument("--query", type=str, required=True, help="Search query")
+    parser.add_argument("--max_results", type=int, default=5, help="Maximum number of search results to display")
+    args = parser.parse_args()
+
+    result = search_web(args.query, max_results=args.max_results)
+    
+    if result.get("error"):
+        print("Search failed:", result["error"])
+    else:
+        results = result.get("results", [])
+        print(f"Displaying up to {args.max_results} results:")
+        for i, res in enumerate(results, start=1):
+            title = res.get("title", "No title")
+            link = res.get("href", "No link")
+            snippet = res.get("body", "No snippet")
+            print(f"{i}. {title}\n   Link: {link}\n   Snippet: {snippet}\n")


### PR DESCRIPTION
# Web Search Integration

This PR adds web search capabilities to the AI VTuber, allowing it to search DuckDuckGo for real-time information.

## How it Works

### 1. Search Trigger
- When the AI needs to search for information, it outputs `[web_search]` followed by the search query.
- **Example:** `[web_search] latest Marvel movie release dates`

### 2. Search Processing
- The search is handled in [`tools/web_search.py`](tools/web_search.py) using DuckDuckGo.
- Search results are limited to 5 by default.
- The query is cleaned by removing `[web_search]` tags and extra formatting.

### 3. Results Processing
- Search results are returned as a dictionary containing:
  - **Title**
  - **URL (href)**
  - **Body text (snippet)**
- The AI then summarizes these results in a conversational way.

### 4. Configuration
- Added in [`conf.yaml`](conf.yaml) under the `tool_prompts` section:
  
  ```yaml
  tool_prompts:
    web_search: "web_search"
  ```

- **Added to persona prompt:**
  
  > **IMPORTANT:** When searching for information, you must **ONLY** output `[web_search]` followed by your search query. Do not add **ANY** other text before or after the search query. Wait for search results before continuing the conversation.

## Dependencies
- Added `duckduckgo_search` to project dependencies.

## Usage
When a user asks for current information, the AI will:
1. Output the search query prefixed with `[web_search]`.
2. Wait for search results.
3. Summarize the findings in a natural, conversational way.

## Known Issues
- The AI sometimes adds commentary to search queries, which needs to be cleaned up.
- Occasionally returns "EOF" if the query includes roleplay actions.

## Future Improvements
- Better query cleaning to remove AI commentary.
- Add support for more search providers.
- Implement rate limiting for searches.
