### PR TITLE
实现了一个非常简洁的，基于Letta的长期记忆版本

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -66,7 +66,7 @@ character_config:
             embedding_model_dims: 1024 # 嵌入模型维度
 
         # mem0 有自己的 llm 设置，与我们的 llm_config 不同。
-        # 有关更多详细信息，请查看他们的文档
+        # 有关更多详细信息，请查看他们的文档      
         llm:
           provider: 'ollama' # 使用的 LLM 提供商
           config:
@@ -89,6 +89,14 @@ character_config:
 
       # MemGPT 配置：MemGPT 暂时被移除
       ##
+
+      letta_agent:
+        host: 'localhost' #主机地址
+        port: 8283 # 端口号
+        id: xxx #letta server运行的Agent的id编号
+        
+        # 一旦选择letta作为agent，那么实际运行时候的llm是在letta上配置的，因此用户需要自己运行letta server
+        # 有关更多详细信息，请查看他们的文档
 
     llm_configs:
       # 一个配置池，用于不同代理中使用的所有无状态 llm 提供商的凭据和连接详细信息

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -94,7 +94,9 @@ character_config:
         host: 'localhost' #主机地址
         port: 8283 # 端口号
         id: xxx #letta server运行的Agent的id编号
-        
+        faster_first_response: True
+        # 句子分割方法：'regex' 或 'pysbd'
+        segment_method: 'pysbd'
         # 一旦选择letta作为agent，那么实际运行时候的llm是在letta上配置的，因此用户需要自己运行letta server
         # 有关更多详细信息，请查看他们的文档
 

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -68,14 +68,6 @@ character_config:
         # mem0 has it's own llm settings and is different from our llm_config.
         # check their docs for more details
 
-      letta_agent:
-        config:
-          host: 'localhost' # Host address
-          port: 8283 # Port number
-          id: xxx # ID number of the Agent running on the Letta server
-        
-        # Once Letta is chosen as the agent, the LLM that runs in practice is configured on Letta, so the user needs to run the Letta server themselves.
-        # For more detailed information, please refer to their documentation.
         llm:
           provider: 'ollama'
           config:
@@ -89,6 +81,16 @@ character_config:
           config:
             model: 'mxbai-embed-large:latest'
             ollama_base_url: 'http://localhost:11434'
+
+      letta_agent:
+        host: 'localhost' # Host address
+        port: 8283 # Port number
+        id: xxx # ID number of the Agent running on the Letta server
+        faster_first_response: True
+        # Method for segmenting sentences: 'regex' or 'pysbd'
+        segment_method: 'pysbd'
+        # Once Letta is chosen as the agent, the LLM that runs in practice is configured on Letta, so the user needs to run the Letta server themselves.
+        # For more detailed information, please refer to their documentation.
         
       hume_ai_agent:
         api_key: ''

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -67,6 +67,15 @@ character_config:
 
         # mem0 has it's own llm settings and is different from our llm_config.
         # check their docs for more details
+
+      letta_agent:
+        config:
+          host: 'localhost' # Host address
+          port: 8283 # Port number
+          id: xxx # ID number of the Agent running on the Letta server
+        
+        # Once Letta is chosen as the agent, the LLM that runs in practice is configured on Letta, so the user needs to run the Letta server themselves.
+        # For more detailed information, please refer to their documentation.
         llm:
           provider: 'ollama'
           config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "uvicorn[standard]>=0.33.0",
     "websocket-client>=1.8.0",
+    "letta-client>=0.1.100",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_bilibili_live.py
+++ b/scripts/run_bilibili_live.py
@@ -2,13 +2,13 @@ import asyncio
 import sys
 import os
 from loguru import logger
+from src.open_llm_vtuber.live.bilibili_live import BiliBiliLivePlatform
+from src.open_llm_vtuber.config_manager.utils import read_yaml, validate_config
 
 # Add project root to path to enable imports
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
-from src.open_llm_vtuber.live.bilibili_live import BiliBiliLivePlatform
-from src.open_llm_vtuber.config_manager.utils import read_yaml, validate_config
 
 
 async def main():

--- a/scripts/run_bilibili_live.py
+++ b/scripts/run_bilibili_live.py
@@ -2,13 +2,13 @@ import asyncio
 import sys
 import os
 from loguru import logger
-from src.open_llm_vtuber.live.bilibili_live import BiliBiliLivePlatform
-from src.open_llm_vtuber.config_manager.utils import read_yaml, validate_config
 
 # Add project root to path to enable imports
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
+from src.open_llm_vtuber.live.bilibili_live import BiliBiliLivePlatform
+from src.open_llm_vtuber.config_manager.utils import read_yaml, validate_config
 
 
 async def main():

--- a/src/open_llm_vtuber/agent/agent_factory.py
+++ b/src/open_llm_vtuber/agent/agent_factory.py
@@ -106,8 +106,8 @@ class AgentFactory:
                 live2d_model=live2d_model,
                 id = settings.get("id"),
                 tts_preprocessor_config=tts_preprocessor_config,
-                faster_first_response = True,
-                segment_method = True,
+                faster_first_response = settings.get("faster_first_response"),
+                segment_method = settings.get("segment_method"),
                 host = settings.get("host"),
                 port = settings.get("port")
             )

--- a/src/open_llm_vtuber/agent/agent_factory.py
+++ b/src/open_llm_vtuber/agent/agent_factory.py
@@ -5,6 +5,7 @@ from .agents.agent_interface import AgentInterface
 from .agents.basic_memory_agent import BasicMemoryAgent
 from .stateless_llm_factory import LLMFactory as StatelessLLMFactory
 from .agents.hume_ai import HumeAIAgent
+from .agents.letta_agent import LettaAgent
 
 
 class AgentFactory:
@@ -97,6 +98,18 @@ class AgentFactory:
                 host=settings.get("host", "api.hume.ai"),
                 config_id=settings.get("config_id"),
                 idle_timeout=settings.get("idle_timeout", 15),
+            )
+
+        elif conversation_agent_choice == "letta_agent":
+            settings = agent_settings.get("letta_agent", {})
+            return LettaAgent(
+                live2d_model=live2d_model,
+                id = settings.get("id"),
+                tts_preprocessor_config=tts_preprocessor_config,
+                faster_first_response = True,
+                segment_method = True,
+                host = settings.get("host"),
+                port = settings.get("port")
             )
 
         else:

--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -1,0 +1,126 @@
+from typing import AsyncIterator, List, Dict, Any
+from loguru import logger
+from .agent_interface import AgentInterface
+from ..output_types import SentenceOutput, DisplayText
+from ..transformers import (
+    sentence_divider,
+    actions_extractor,
+    tts_filter,
+    display_processor,
+)
+from ...config_manager import TTSPreprocessorConfig
+from ..input_types import BatchInput, TextSource
+from letta_client import Letta
+
+class LettaAgent(AgentInterface):
+    """
+    Custom Letta class to interface with the Letta server.
+    """
+
+    def __init__(
+            self,
+            live2d_model,
+            id,
+            tts_preprocessor_config: TTSPreprocessorConfig = None,
+            faster_first_response: bool = True,
+            segment_method: str = "pysbd",
+            host: str = "localhost",
+            port: int = 8283
+                 ):
+        super().__init__()
+        self.url = f"http://{host}:{port}"
+        self.client = Letta(base_url=self.url)
+        self.id = id
+        # Initialize decorator parameters
+        self._tts_preprocessor_config = tts_preprocessor_config
+        self._live2d_model = live2d_model
+        self._faster_first_response = faster_first_response
+        self._segment_method = segment_method
+
+        # Delay decorator application
+        self.chat = tts_filter(self._tts_preprocessor_config)(
+            display_processor()(
+                actions_extractor(self._live2d_model)(
+                    sentence_divider(
+                        faster_first_response=self._faster_first_response,
+                        segment_method=self._segment_method,
+                        valid_tags=["think"],
+                    )(self.chat)
+                )
+            )
+        )
+
+    def set_memory_from_history(self, conf_uid: str, history_uid: str) -> None:
+        # The Letta Server automatically stores historical messages, so this part is not needed
+        pass
+
+    def handle_interrupt(self, heard_response: str) -> None:
+        pass
+    
+    async def generator_to_async(self, gen):
+        for item in gen:
+            yield item
+
+    async def chat(self, input_data: BatchInput) -> AsyncIterator[SentenceOutput]:
+        messages = self._to_messages(input_data)
+        stream = self.generator_to_async(self.client.agents.messages.create_stream(
+            agent_id=self.id,
+            messages=messages,
+            stream_tokens=True,
+        ))
+
+        complete_response = ""
+        async for token in stream:
+            if token.message_type == 'reasoning_message':
+                # This part is reasoning information and should not be displayed
+                token = token.reasoning
+                continue
+            elif token.message_type == 'assistant_message':
+                # This part is the result that needs to be displayed, it is the final result
+                # logger.info('Test message')
+                # logger.info(token)
+                token = token.content
+            else:
+                continue
+
+            yield token
+            complete_response += token
+
+    def _to_text_prompt(self, input_data: BatchInput) -> str:
+        """
+        Format BatchInput into a prompt string for the LLM.
+
+        Args:
+            input_data: BatchInput - The input data containing texts
+
+        Returns:
+            str - Formatted message string
+        """
+        message_parts = []
+
+        # Process text inputs in order
+        for text_data in input_data.texts:
+            if text_data.source == TextSource.INPUT:
+                message_parts.append(text_data.content)
+            elif text_data.source == TextSource.CLIPBOARD:
+                message_parts.append(f"[Clipboard content: {text_data.content}]")
+
+        return "\n".join(message_parts)
+
+    def _to_messages(self, input_data: BatchInput) -> List[Dict[str, Any]]:
+        """
+        Prepare messages list without image support.
+        """
+        messages = []
+
+        if input_data.images:
+            content = []
+            text_content = self._to_text_prompt(input_data)
+            content.append({"type": "text", "text": text_content})
+            user_message = {"role": "user", "content": content}
+        else:
+            user_message = {"role": "user", "content": self._to_text_prompt(input_data)}
+
+        messages.append(user_message)
+
+        return messages

--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -1,7 +1,6 @@
 from typing import AsyncIterator, List, Dict, Any
-from loguru import logger
 from .agent_interface import AgentInterface
-from ..output_types import SentenceOutput, DisplayText
+from ..output_types import SentenceOutput
 from ..transformers import (
     sentence_divider,
     actions_extractor,

--- a/src/open_llm_vtuber/config_manager/agent.py
+++ b/src/open_llm_vtuber/config_manager/agent.py
@@ -132,6 +132,29 @@ class HumeAIConfig(I18nMixin, BaseModel):
         ),
     }
 
+# =================================
+
+
+class LettaConfig(I18nMixin, BaseModel):
+    """Configuration for the Letta agent."""
+    host: str = Field("localhost", alias="host")
+    port: int = Field(8283, alias="port")
+    id: str = Field(..., alias="id")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+    "host": Description(
+        en="Host address for the Letta server", zh="Letta服务器的主机地址"
+    ),
+    "port": Description(
+        en="Port number for the Letta server (default: 8283)", zh="Letta服务器的端口号（默认：8283）"
+    ),
+    "id": Description(
+        en="Agent instance ID running on the Letta server", zh="指定Letta服务器上运行的Agent实例id"
+    ),
+    }
+
+
+
 
 class AgentSettings(I18nMixin, BaseModel):
     """Settings for different types of agents."""
@@ -141,6 +164,7 @@ class AgentSettings(I18nMixin, BaseModel):
     )
     mem0_agent: Optional[Mem0Config] = Field(None, alias="mem0_agent")
     hume_ai_agent: Optional[HumeAIConfig] = Field(None, alias="hume_ai_agent")
+    letta_agent: Optional[LettaConfig] = Field(None, alias="letta_agent")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "basic_memory_agent": Description(
@@ -150,6 +174,9 @@ class AgentSettings(I18nMixin, BaseModel):
         "hume_ai_agent": Description(
             en="Configuration for Hume AI agent", zh="Hume AI 代理配置"
         ),
+        "letta_agent": Description(
+            en="Configuration for Letta agent", zh="Letta 代理配置"
+        )
     }
 
 
@@ -157,7 +184,7 @@ class AgentConfig(I18nMixin, BaseModel):
     """This class contains all of the configurations related to agent."""
 
     conversation_agent_choice: Literal[
-        "basic_memory_agent", "mem0_agent", "hume_ai_agent"
+        "basic_memory_agent", "mem0_agent", "hume_ai_agent", "letta_agent"
     ] = Field(..., alias="conversation_agent_choice")
     agent_settings: AgentSettings = Field(..., alias="agent_settings")
     llm_configs: StatelessLLMConfigs = Field(..., alias="llm_configs")

--- a/src/open_llm_vtuber/config_manager/agent.py
+++ b/src/open_llm_vtuber/config_manager/agent.py
@@ -140,6 +140,8 @@ class LettaConfig(I18nMixin, BaseModel):
     host: str = Field("localhost", alias="host")
     port: int = Field(8283, alias="port")
     id: str = Field(..., alias="id")
+    faster_first_response: Optional[bool] = Field(True, alias="faster_first_response")
+    segment_method: Literal["regex", "pysbd"] = Field("pysbd", alias="segment_method")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
     "host": Description(
@@ -198,5 +200,13 @@ class AgentConfig(I18nMixin, BaseModel):
         ),
         "llm_configs": Description(
             en="Pool of LLM provider configurations", zh="语言模型提供者配置池"
+        ),
+        "faster_first_response": Description(
+            en="Whether to respond as soon as encountering a comma in the first sentence to reduce latency (default: True)",
+            zh="是否在第一句回应时遇上逗号就直接生成音频以减少首句延迟（默认：True）",
+        ),
+        "segment_method": Description(
+            en="Method for segmenting sentences: 'regex' or 'pysbd' (default: 'pysbd')",
+            zh="分割句子的方法：'regex' 或 'pysbd'（默认：'pysbd'）",
         ),
     }

--- a/src/open_llm_vtuber/live/bilibili_live.py
+++ b/src/open_llm_vtuber/live/bilibili_live.py
@@ -3,7 +3,7 @@ import http.cookies
 import random
 import traceback
 import json
-from typing import Callable, Dict, Any, List, Optional, Set
+from typing import Callable, Dict, Any, List, Optional
 from loguru import logger
 import aiohttp
 import websockets

--- a/src/open_llm_vtuber/live/live_interface.py
+++ b/src/open_llm_vtuber/live/live_interface.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import asyncio
-from typing import Callable, Optional, List, Dict, Any
-from loguru import logger
+from typing import Callable, Dict, Any
 
 
 class LivePlatformInterface(ABC):

--- a/src/open_llm_vtuber/proxy_handler.py
+++ b/src/open_llm_vtuber/proxy_handler.py
@@ -1,12 +1,11 @@
 import asyncio
 import json
 import uuid
-from typing import Dict, Set, Optional, List, Deque
+from typing import Dict, Optional
 from fastapi import WebSocket
 from loguru import logger
 import aiohttp
 from starlette.websockets import WebSocketDisconnect
-from collections import deque
 
 from .proxy_message_queue import ProxyMessageQueue
 

--- a/src/open_llm_vtuber/server.py
+++ b/src/open_llm_vtuber/server.py
@@ -3,8 +3,7 @@ import shutil
 
 from fastapi import FastAPI, Request
 from starlette.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from starlette.responses import Response, FileResponse
+from starlette.responses import Response
 from starlette.staticfiles import StaticFiles as StarletteStaticFiles
 
 from .routes import init_client_ws_route, init_webtool_routes, init_proxy_route


### PR DESCRIPTION
# 实现了一个非常简洁的，基于Letta的长期记忆版本
只需要给定Letta服务器的ip，端口，以及对应的Agent-id，即可使用。
但需要用户会使用Letta Server。
### 具体修改内容如下：
* 修改了中英版本的配置模板文件，新增了关于Letta的配置
* 在config\_manager中加入了关于Letta的设定
* 在Agent/agents文件夹下新增了关于Letta的代码
* 在AgentFactory中加入了创建LettaAgent的代码
* 需要下载letta-cient包才能使用
### 优点
* 简单易用，记忆效果还不错。
* Letta本身自带图形化界面，可以直接可视化记忆库
* 只需要考虑单个句子的输入即可，历史信息由Letta Server自动记录
### 缺点
* 会导致速度变慢一些
* 目前还在完善功能，有一些原来的功能暂时使用不了，例如显示情绪标签，以及图片的支持
### 注意
* 对LLM模型的配置是在Letta Server上完成的，所以一旦使用Letta作为Agent，那么conf.yaml中对于llm的配置会失效，而Letta的llm配置才是最终的。
* 有问题欢迎联系我，我也只是小小本科生，目前还在学习当中