### PR TITLE
关于faster-whisper模型使用和自动识别语言逻辑修复以及根据不同设备的性能选择不同大小的模型

### DIFF
--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -170,7 +170,6 @@ character_config:
       model_path: 'distil-medium.en' # distil-medium.en is an English-only model
       #                               use distil-large-v3 if you have a good GPU
       download_root: 'models/whisper'
-      language: 'en' # en, zh, or something else. put nothing for auto-detect.
       device: 'auto' # cpu, cuda, or auto. faster-whisper doesn't support mps
 
     whisper_cpp:

--- a/src/open_llm_vtuber/asr/asr_factory.py
+++ b/src/open_llm_vtuber/asr/asr_factory.py
@@ -11,7 +11,6 @@ class ASRFactory:
             return FasterWhisperASR(
                 model_path=kwargs.get("model_path"),
                 download_root=kwargs.get("download_root"),
-                language=kwargs.get("language"),
                 device=kwargs.get("device"),
             )
         elif system_name == "whisper_cpp":

--- a/src/open_llm_vtuber/asr/faster_whisper_asr.py
+++ b/src/open_llm_vtuber/asr/faster_whisper_asr.py
@@ -11,11 +11,9 @@ class VoiceRecognition(ASRInterface):
         self,
         model_path: str = "distil-medium.en",
         download_root: str = None,
-        language: str = "en",
         device: str = "auto",
     ) -> None:
         self.MODEL_PATH = model_path
-        self.LANG = language
 
         self.model = WhisperModel(
             model_path,
@@ -28,7 +26,6 @@ class VoiceRecognition(ASRInterface):
         segments, info = self.model.transcribe(
             audio,
             beam_size=5 if self.BEAM_SEARCH else 1,
-            language=self.LANG,
             condition_on_previous_text=False,
         )
 


### PR DESCRIPTION
首先删除1.1的conf.yaml里的172行language: "en" # en, zh, or something else. put nothing for auto-detect.这段注释的描述不准确，无论是哪个faster-whisper模型都是可以自动识别语言的。
然后删除1.1的asr_factory.py里的14行language=kwargs.get("language")和1.1的faster_whisper_asr.py里的14行 language: str = "en"和18行self.LANG = language和31行的language=self.LANG,并且推荐把24行的compute_type="float32",中的float32改为int8，因为int8速度更快。另外如果改本地文件路径的话需要改conf.yaml和faster_whisper_asr.py里的路径，建议直接去魔搭上用网页下载因为我用modelscope下载有些老是卡在0%，原因不明。使用之前还需要uv add faster_whisper。

使用22秒生成音频走int8测试13代i5和8G4060装有12.8的cuda和9.8的cudnn参考结果如下：cpu部分是v3-turbo用时5.98秒、small是1.56秒，显卡是v3-turbo用时1.04秒、small用时0.48秒。总结：没有4060就选small，因为medium和v3-turbo差不多大小，small可能是比如20系30系保证速度的前提下识别效果最好的。有4060就选v3-turbo，速度没问题的话精度自然越高越好。精度参考资料：faster-whisper-small是2.44亿参数，faster-whisper-v3-turbo是8.09亿参数。