### PR TITLE
BUG FIX: OpenAI-Whisper

### DIFF
--- a/src/open_llm_vtuber/asr/asr_interface.py
+++ b/src/open_llm_vtuber/asr/asr_interface.py
@@ -20,6 +20,8 @@ class ASRInterface(metaclass=abc.ABCMeta):
         Returns:
             str: The transcription result.
         """
+        if audio.dtype != np.float32:
+            audio = audio.astype(np.float32)
         return await asyncio.to_thread(self.transcribe_np, audio)
 
     @abc.abstractmethod

--- a/src/open_llm_vtuber/asr/openai_whisper_asr.py
+++ b/src/open_llm_vtuber/asr/openai_whisper_asr.py
@@ -17,8 +17,6 @@ class VoiceRecognition(ASRInterface):
         )
 
     def transcribe_np(self, audio: np.ndarray) -> str:
-        segments = self.model.transcribe(audio)
-        full_text = ""
-        for segment in segments:
-            full_text += segment
+        result = self.model.transcribe(audio)
+        full_text = result['text']
         return full_text


### PR DESCRIPTION
This PR fixes two issues found in our openai-whisper integration:

1. **Audio dtype mismatch:**  
   Sometimes, transcribing audio failed with an error like  

   ```
   expected m1 and m2 to have the same dtype, but got: float != double
   ```

   Solution:  
   Added the following before calling whisper, to make sure input is always `np.float32`:

   ```python
   if audio.dtype != np.float32:
       audio = audio.astype(np.float32)
   ```

2. **Incorrect transcription output:**   
   The previous `transcribe_np` implementation would always return the same string (e.g. "textsegmentslanguage") regardless of what the user actually said.  
   Example log:

   ```
   2025-05-02 12:53:44 | INFO     | src.open_llm_vtuber.conversations.single_conversation:process_single_conversation:49 | New Conversation Chain 🌿 started!
   2025-05-02 12:53:44 | INFO     | src.open_llm_vtuber.conversations.conversation_utils:process_user_input:151 | Transcribing audio input...
   2025-05-02 12:53:48 | INFO     | src.open_llm_vtuber.conversations.single_conversation:process_single_conversation:72 | User input: textsegmentslanguage
   ```

   Fix: Now we extract the `'text'` field from the result dictionary returned by `whisper.transcribe()`, so it actually returns the right transcript.

Both issues are now fixed.  