### PR TITLE
feat: 新增TTS自动化批量测试脚本，开发中

### DIFF
--- a/scripts/test_tts.py
+++ b/scripts/test_tts.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import yaml
+import numpy as np
+import librosa
+import re
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.open_llm_vtuber.tts.tts_factory import TTSFactory
+from src.open_llm_vtuber.asr.asr_factory import ASRFactory
+
+def load_config(config_path="conf.yaml"):
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+    return config
+
+def get_tts_instance(tts_config):
+    tts_model = tts_config["tts_model"]
+    tts_params = tts_config.get(tts_model, {})
+    return TTSFactory.get_tts_engine(tts_model, **tts_params)
+
+def get_asr_instance(asr_config):
+    asr_model = asr_config["asr_model"]
+    asr_params = asr_config.get(asr_model, {})
+    return ASRFactory.get_asr_system(asr_model, **asr_params)
+
+def remove_punctuation(text):
+    # Remove all punctuation and spaces, keep letters/numbers/Chinese
+    return re.sub(r"[^\w\u4e00-\u9fff]+", "", text).lower()
+
+def audio_duration(audio_path):
+    y, sr = librosa.load(audio_path, sr=None)
+    return len(y) / sr
+
+def wav_to_np(audio_path):
+    y, sr = librosa.load(audio_path, sr=16000, mono=True)
+    return y
+
+def main():
+    config = load_config()
+    try:
+        tts_config = config["character_config"]["tts_config"]
+        asr_config = config["character_config"]["asr_config"]
+    except KeyError as e:
+        print(f"[ERROR] 配置文件缺少键: {e}")
+        print(f"可用顶层键: {list(config.keys())}")
+        print("请检查 conf.yaml 结构，确保包含 tts_config 和 asr_config。")
+        return
+
+    tts = get_tts_instance(tts_config)
+    asr = get_asr_instance(asr_config)
+
+    test_sentences = [
+        "Hello, this is a TTS test.",
+        "今天天气不错，适合出去散步。",
+        "Open-LLM-VTuber 项目正在测试语音合成。",
+        "The quick brown fox jumps over the lazy dog.",
+        "请说出下面这句话：你好，世界！"
+    ]
+
+    print(f"Testing TTS: {tts_config['tts_model']}  |  ASR: {asr_config['asr_model']}")
+    print("=" * 60)
+
+    for idx, text in enumerate(test_sentences):
+        print(f"Test {idx+1}: \"{text}\"")
+        # 生成音频
+        audio_path = tts.generate_audio(text, file_name_no_ext=f"test_tts_{idx}")
+        # 检查音频长度
+        duration = audio_duration(audio_path)
+        if duration < 0.5 or duration > 20:
+            print(f"  [FAIL] Audio duration abnormal: {duration:.2f}s")
+            continue
+        # 识别
+        audio_np = wav_to_np(audio_path)
+        try:
+            recognized = asr.transcribe_np(audio_np)
+        except Exception as e:
+            print(f"  [FAIL] ASR error: {e}")
+            continue
+        # 对比文本
+        ref = remove_punctuation(text)
+        hyp = remove_punctuation(recognized)
+        # 简单相似度判定
+        match = (ref in hyp) or (hyp in ref) or (len(set(ref) & set(hyp)) / max(len(ref), 1) > 0.7)
+        if match:
+            print(f"  [PASS] ASR: {recognized}  (duration: {duration:.2f}s)")
+        else:
+            print(f"  [FAIL] ASR: {recognized}  (duration: {duration:.2f}s)")
+    print("=" * 60)
+    print("TTS/ASR test finished.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_tts.py
+++ b/scripts/test_tts.py
@@ -1,25 +1,57 @@
 import os
 import sys
 import yaml
-import numpy as np
 import librosa
 import re
 from pathlib import Path
+from rapidfuzz import fuzz
+import argparse
 
 sys.path.append(str(Path(__file__).parent.parent))
 
 from src.open_llm_vtuber.tts.tts_factory import TTSFactory
 from src.open_llm_vtuber.asr.asr_factory import ASRFactory
 
+# 1. Rename 'special' key to 'symbols'
+TEST_CASES = {
+    "english": [
+        "Hello, this is a standard functionality test.",
+        "The quick brown fox jumps over the lazy dog.",
+        "How much wood would a woodchuck chuck if a woodchuck could chuck wood?",
+        "To be, or not to be, that is the question.",
+        "The temperature is seventy-two degrees Fahrenheit."
+    ],
+    "chinese": [
+        "你好，这是一个标准的功能性测试。",
+        "今天天气不错，适合出去散步。",
+        "床前明月光，疑是地上霜。",
+        "中华人民共和国的首都是北京。",
+        "这是一项测试语音合成流畅度的长句子。"
+    ],
+    "mixed": [
+        "这个 Open-LLM-VTuber 项目真是太酷了！",
+        "我今天会给你发一封 email，请注意查收。",
+        "我们去 costco 买点 pizza 怎么样？",
+        "这个 bug 的复现概率是 50%。",
+        "请帮我 search 一下 '人工智能' 的最新进展。"
+    ],
+    "symbols": [ # <-- RENAMED
+        "Okay... let's try this: <a> 'https://example.com' & `code`!",
+        "Wow! 🎉 Is this real? 🤯 (50% off!)",
+        "She said: \"It's a-m-a-z-i-n-g!\" #blessed",
+        "He paid $1,234.56 for the new computer @ Apple Store.",
+        "Hi👋，这是一个带有emoji和很多符号的句子，【系统】会卡住吗？"
+    ]
+}
+
 def load_config(config_path="conf.yaml"):
     with open(config_path, "r", encoding="utf-8") as f:
-        config = yaml.safe_load(f)
-    return config
+        return yaml.safe_load(f)
 
-def get_tts_instance(tts_config):
-    tts_model = tts_config["tts_model"]
-    tts_params = tts_config.get(tts_model, {})
-    return TTSFactory.get_tts_engine(tts_model, **tts_params)
+def get_tts_instance(config, tts_model_name):
+    """Get a TTS instance based on the specified model name."""
+    tts_params = config["character_config"]["tts_config"].get(tts_model_name, {})
+    return TTSFactory.get_tts_engine(tts_model_name, **tts_params)
 
 def get_asr_instance(asr_config):
     asr_model = asr_config["asr_model"]
@@ -27,69 +59,145 @@ def get_asr_instance(asr_config):
     return ASRFactory.get_asr_system(asr_model, **asr_params)
 
 def remove_punctuation(text):
-    # Remove all punctuation and spaces, keep letters/numbers/Chinese
     return re.sub(r"[^\w\u4e00-\u9fff]+", "", text).lower()
 
 def audio_duration(audio_path):
-    y, sr = librosa.load(audio_path, sr=None)
-    return len(y) / sr
+    try:
+        y, sr = librosa.load(audio_path, sr=None)
+        return len(y) / sr
+    except Exception as e:
+        return -1 # Indicates failure to load
 
 def wav_to_np(audio_path):
     y, sr = librosa.load(audio_path, sr=16000, mono=True)
     return y
 
-def main():
-    config = load_config()
-    try:
-        tts_config = config["character_config"]["tts_config"]
-        asr_config = config["character_config"]["asr_config"]
-    except KeyError as e:
-        print(f"[ERROR] 配置文件缺少键: {e}")
-        print(f"可用顶层键: {list(config.keys())}")
-        print("请检查 conf.yaml 结构，确保包含 tts_config 和 asr_config。")
-        return
+def calculate_similarity(ref_text, hyp_text):
+    return fuzz.ratio(ref_text, hyp_text)
 
-    tts = get_tts_instance(tts_config)
+def print_summary_report(results):
+    """Print a formatted summary report at the end of the script."""
+    print("\n" + "="*30 + " Automated Test Report " + "="*30)
+    
+    current_tts = ""
+    for result in results:
+        if result['tts_engine'] != current_tts:
+            current_tts = result['tts_engine']
+            print(f"\n--- TTS Engine: {current_tts} ---")
+
+        status_icon = "✅" if result['status'] == 'PASS' else "❌"
+        print(f"\n{status_icon} Test Case {result['id']}: {result['status']}")
+        print(f"  - Original Text: \"{result['original_text']}\"")
+        if result['recognized_text'] is not None:
+            # For 'symbols', this is for reference only
+            label = "Recognized Text" if result['similarity'] is not None else "Recognized Text (for reference)"
+            print(f"  - {label}: \"{result['recognized_text']}\"")
+        if result['similarity'] is not None:
+            print(f"  - Similarity: {result['similarity']:.2f}%")
+        print(f"  - Audio File: {result['audio_path']}")
+        
+    print("\n" + "="*75)
+    print("End of Report.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Automated testing script for TTS and ASR systems.")
+    parser.add_argument(
+        '--test_case', 
+        type=str, 
+        choices=['english', 'chinese', 'mixed', 'symbols'], 
+        default='english',
+        help='Select the test case category to run (default: english)'
+    )
+    parser.add_argument(
+        '--tts', 
+        nargs='+',
+        help='Specify one or more TTS engines to test (e.g., edge_tts). If not specified, the default from conf.yaml is used.'
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+    asr_config = config["character_config"]["asr_config"]
     asr = get_asr_instance(asr_config)
 
-    test_sentences = [
-        "Hello, this is a TTS test.",
-        "今天天气不错，适合出去散步。",
-        "Open-LLM-VTuber 项目正在测试语音合成。",
-        "The quick brown fox jumps over the lazy dog.",
-        "请说出下面这句话：你好，世界！"
-    ]
+    if args.tts:
+        tts_engines_to_test = args.tts
+    else:
+        tts_engines_to_test = [config["character_config"]["tts_config"]["tts_model"]]
+        
+    selected_cases = TEST_CASES[args.test_case]
+    similarity_threshold = 70.0
+    all_results = []
 
-    print(f"Testing TTS: {tts_config['tts_model']}  |  ASR: {asr_config['asr_model']}")
-    print("=" * 60)
-
-    for idx, text in enumerate(test_sentences):
-        print(f"Test {idx+1}: \"{text}\"")
-        # 生成音频
-        audio_path = tts.generate_audio(text, file_name_no_ext=f"test_tts_{idx}")
-        # 检查音频长度
-        duration = audio_duration(audio_path)
-        if duration < 0.5 or duration > 20:
-            print(f"  [FAIL] Audio duration abnormal: {duration:.2f}s")
-            continue
-        # 识别
-        audio_np = wav_to_np(audio_path)
+    print(f"Starting test... Category: '{args.test_case}', TTS Engines: {tts_engines_to_test}")
+    
+    for tts_engine_name in tts_engines_to_test:
+        print("\n" + "="*60)
+        print(f"Testing TTS Engine: {tts_engine_name}")
+        print("="*60)
+        
         try:
-            recognized = asr.transcribe_np(audio_np)
+            tts = get_tts_instance(config, tts_engine_name)
         except Exception as e:
-            print(f"  [FAIL] ASR error: {e}")
+            print(f"[ERROR] Failed to initialize TTS engine '{tts_engine_name}': {e}")
             continue
-        # 对比文本
-        ref = remove_punctuation(text)
-        hyp = remove_punctuation(recognized)
-        # 简单相似度判定
-        match = (ref in hyp) or (hyp in ref) or (len(set(ref) & set(hyp)) / max(len(ref), 1) > 0.7)
-        if match:
-            print(f"  [PASS] ASR: {recognized}  (duration: {duration:.2f}s)")
-        else:
-            print(f"  [FAIL] ASR: {recognized}  (duration: {duration:.2f}s)")
-    print("=" * 60)
-    print("TTS/ASR test finished.")
+
+        for idx, text in enumerate(selected_cases):
+            test_id = f"{args.test_case}_{idx+1}"
+            print(f"\nRunning Test {test_id}: \"{text}\"")
+            
+            result_data = {
+                'tts_engine': tts_engine_name,
+                'id': test_id,
+                'original_text': text,
+                'recognized_text': None,
+                'similarity': None,
+                'status': 'FAIL',
+                'audio_path': 'N/A'
+            }
+
+            try:
+                filename = f"{tts_engine_name}_{test_id}"
+                audio_path = tts.generate_audio(text, file_name_no_ext=filename)
+                result_data['audio_path'] = audio_path
+                
+                duration = audio_duration(audio_path)
+                if duration < 0:
+                    print(f"  [FAIL] Could not load the generated audio file.")
+                    all_results.append(result_data)
+                    continue
+                
+                print(f"  - Audio generated successfully, duration: {duration:.2f}s")
+
+                # 2. Add ASR transcription for all cases, including 'symbols'
+                audio_np = wav_to_np(audio_path)
+                recognized = asr.transcribe_np(audio_np)
+                result_data['recognized_text'] = recognized
+
+                # 3. Logic is now split: 'symbols' case has different pass criteria
+                if args.test_case == 'symbols':
+                    result_data['status'] = 'PASS' # Generation success is the only criterion
+                    print(f"  - ASR (for reference): {recognized}")
+                    print("  [PASS] Symbols test passed (only checked for successful generation).")
+                else: # Logic for 'english', 'chinese', 'mixed'
+                    ref = remove_punctuation(text)
+                    hyp = remove_punctuation(recognized)
+                    similarity = calculate_similarity(ref, hyp)
+                    result_data['similarity'] = similarity
+
+                    if similarity >= similarity_threshold:
+                        result_data['status'] = 'PASS'
+                        print(f"  [PASS] ASR: {recognized} (Similarity: {similarity:.2f}%)")
+                    else:
+                        print(f"  [FAIL] ASR: {recognized} (Similarity: {similarity:.2f}%)")
+
+            except Exception as e:
+                print(f"  [FAIL] An unexpected error occurred during test execution: {e}")
+            
+            all_results.append(result_data)
+
+    print_summary_report(all_results)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
为了方便开发者调试和验证新增的TTS，以及确保现有TTS的稳定性，新增了一个自动化测试脚本 `scripts/test_tts.py`。这个脚本通过利用ASR来自动判断TTS是否稳定。

目前是默认用conf.yaml里面指定的asr model作为judge model，tts model可以手动指定，如果不填的话也会自动读取conf.yaml中的TTS model
现在写了四种test case，分别是`['english', 'chinese', 'mixed', 'symbols']`，默认为english，其中`symbols`是指带有特殊符号的输入情况。
使用方法可以参考下面这个例子（测试英文，指定tts model为edge_tts和coqui_tts）：
```bash
python scripts/test_tts.py --test_case symbols --tts edge_tts coqui_tts
```
**输出示例:**
```
============================== Automated Test Report ==============================

--- TTS Engine: edge_tts ---

✅ Test Case english_1: PASS
  - Original Text: "Hello, this is a standard functionality test."
  - Recognized Text: "Hello, this is a standard functionality test."
  - Similarity: 100.00%
  - Audio File: cache/edge_tts_english_1.mp3

... (省略部分输出) ...

--- TTS Engine: coqui_tts ---

✅ Test Case english_2: PASS
  - Original Text: "The quick brown fox jumps over the lazy dog."
  - Recognized Text: "The quakebro fox jumps over the lazy dog."
  - Similarity: 91.18%
  - Audio File: cache/coqui_tts_english_2.wav

... (省略部分输出) ...

===========================================================================
End of Report.
```
其中`Similarity`是通过rapidfuzz这个库自动计算文本距离来判定的，目前设置的阈值是70以下为不通过（因为有asr的精度问题）

测试特殊符号的时候，我们不采用这个指标来判定，因为不同tts对于特殊符号的反应不太一样，不太好直接进行判断，所以仅通过asr提供了一个作为参考的文本。
```bash
python scripts/test_tts.py --test_case symbols --tts edge_tts coqui_tts
```
输出示例:
```
============================== Automated Test Report ==============================

--- TTS Engine: edge_tts ---

✅ Test Case symbols_1: PASS
  - Original Text: "Okay... let's try this: <a> 'https://example.com' & `code`!"
  - Recognized Text (for reference): "Okay, let's try this, A Httpscolon s/lashexle.com and code."
  - Audio File: cache/edge_tts_symbols_1.mp3

... (省略部分输出) ...

--- TTS Engine: coqui_tts ---

✅ Test Case symbols_1: PASS
  - Original Text: "Okay... let's try this: <a> 'https://example.com' & `code`!"
  - Recognized Text (for reference): "Okay."
  - Audio File: cache/coqui_tts_symbols_1.wav

... (省略部分输出) ...

===========================================================================
End of Report.
```

目前这个脚本还处于初版阶段，非常欢迎大家一起讨论如何继续完善它