### PR TITLE
Move check_user_config_exists call to upgrade.py

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -3,6 +3,7 @@ from upgrade_codes.upgrade_manager import UpgradeManager
 from upgrade_codes.upgrade_core.constants import TEXTS
 
 upgrade_manager = UpgradeManager()
+upgrade_manager.check_user_config_exists()
 
 def run_upgrade():
     logger = upgrade_manager.logger

--- a/upgrade_codes/upgrade_manager.py
+++ b/upgrade_codes/upgrade_manager.py
@@ -16,7 +16,6 @@ class UpgradeManager:
         self.upgrade_utils = UpgradeUtility(self.logger, self.lang)
         self.config_sync = ConfigSynchronizer(self.lang, self.logger)
         self.texts = TEXTS
-        self.check_user_config_exists()
 
     def check_user_config_exists(self):
         if not os.path.exists(USER_CONF):


### PR DESCRIPTION
The call to check_user_config_exists was moved from the UpgradeManager constructor to upgrade.py. This change ensures user config existence is checked explicitly where needed, rather than automatically during UpgradeManager initialization.