### PR TITLE
Add local-hosted FishTTS provider

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -328,6 +328,17 @@ character_config:
       latency: 'balanced' # 延迟
       base_url: 'https://api.fish.audio' # 基础 URL
 
+    fish_tts_local:
+      # 本地 Fish TTS 服务器的 API 密钥，默认为“YOUR_API_KEY”。
+      api_key: 'YOUR_API_KEY'
+      # 6-10秒的参考音频
+      reference_audio: 'voice.wav'
+      reference_text: '音频中的文字'
+      # 要么是“normal”，要么是“balanced”。平衡速度更快，但质量较低。
+      latency: 'normal'
+      api_url: 'http://127.0.0.1:8080/v1/tts'
+      max_new_tokens: 512
+
     coqui_tts:
       # 要使用的 TTS 模型的名称。如果为空，将使用默认模型
       # 执行 'tts --list_models' 以列出 coqui-tts 支持的模型

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -332,6 +332,17 @@ character_config:
       latency: 'balanced'
       base_url: 'https://api.fish.audio'
 
+    fish_tts_local:
+      # The API key for the local Fish TTS server, "YOUR_API_KEY" by default.
+      api_key: 'YOUR_API_KEY'
+      # 6-10 seconds of reference audio
+      reference_audio: 'voice.wav'
+      reference_text: 'TEXT SPOKEN IN THE AUDIO'
+      # Either 'normal' or 'balanced'. balance is faster but lower quality.
+      latency: 'normal'
+      api_url: 'http://127.0.0.1:8080/v1/tts'
+      max_new_tokens: 512
+
     coqui_tts:
       # Name of the TTS model to use. If empty, will use default model
       # do 'tts --list_models' to list supported models for coqui-tts

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -232,7 +232,7 @@ class FishTTSLocalConfig(I18nMixin):
     reference_id: Optional[str] = Field(None, alias="reference_id")
     reference_audio: Optional[str] = Field(None, alias="reference_audio")
     reference_text: Optional[str] = Field(None, alias="reference_text")
-    base_url: str = Field("http://127.0.0.1:8080/v1/tts", alias="base_url")
+    api_url: str = Field("http://127.0.0.1:8080/v1/tts")
     latency: Literal["normal", "balanced"] = Field("normal", alias="latency")
     audio_format: str = Field("wav", alias="audio_format")
     max_new_tokens: int = Field(1024, alias="max_new_tokens")
@@ -263,7 +263,7 @@ class FishTTSLocalConfig(I18nMixin):
             en="List of reference texts for voice synthesis",
             zh="用于语音合成的参考文本列表"
         ),
-        "base_url": Description(
+        "api_url": Description(
             en="Base URL for TTS API",
             zh="TTS API 的基础 URL"
         ),

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -1,6 +1,6 @@
 # config_manager/tts.py
 from pydantic import ValidationInfo, Field, model_validator
-from typing import Literal, Optional, Dict, ClassVar
+from typing import Literal, Optional, List, Dict, ClassVar
 from .i18n import I18nMixin, Description
 
 

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -225,6 +225,98 @@ class FishAPITTSConfig(I18nMixin):
         ),
     }
 
+class FishTTSLocalConfig(I18nMixin):
+    """Configuration for TTS Engine."""
+    
+    api_key: str = Field(..., alias="api_key")
+    reference_id: Optional[str] = Field(None, alias="reference_id")
+    reference_audio: Optional[List[str]] = Field(None, alias="reference_audio")
+    reference_text: Optional[List[str]] = Field(None, alias="reference_text")
+    base_url: str = Field("http://127.0.0.1:8080/v1/tts", alias="base_url")
+    latency: Literal["normal", "balanced"] = Field("normal", alias="latency")
+    audio_format: str = Field("wav", alias="audio_format")
+    max_new_tokens: int = Field(1024, alias="max_new_tokens")
+    chunk_length: int = Field(300, alias="chunk_length")
+    top_p: float = Field(0.8, alias="top_p")
+    repetition_penalty: float = Field(1.1, alias="repetition_penalty")
+    temperature: float = Field(0.8, alias="temperature")
+    streaming: bool = Field(False, alias="streaming")
+    channels: int = Field(1, alias="channels")
+    rate: int = Field(44100, alias="rate")
+    use_memory_cache: str = Field("off", alias="use_memory_cache")
+    seed: Optional[int] = Field(None, alias="seed")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "api_key": Description(
+            en="API key for TTS service",
+            zh="TTS 服务的 API 密钥"
+        ),
+        "reference_id": Description(
+            en="Voice reference ID from service provider",
+            zh="来自服务提供商的语音参考 ID"
+        ),
+        "reference_audio": Description(
+            en="List of reference audio file paths",
+            zh="参考音频文件路径列表"
+        ),
+        "reference_text": Description(
+            en="List of reference texts for voice synthesis",
+            zh="用于语音合成的参考文本列表"
+        ),
+        "base_url": Description(
+            en="Base URL for TTS API",
+            zh="TTS API 的基础 URL"
+        ),
+        "latency": Description(
+            en="Latency mode (normal or balanced)",
+            zh="延迟模式（normal 或 balanced）"
+        ),
+        "audio_format": Description(
+            en="Output audio format (wav, mp3, flac)",
+            zh="输出音频格式（wav, mp3, flac）"
+        ),
+        "max_new_tokens": Description(
+            en="Maximum new tokens to generate (0 means no limit)",
+            zh="生成的最大新 token 数（0 表示无限制）"
+        ),
+        "chunk_length": Description(
+            en="Chunk length for synthesis",
+            zh="合成的块长度"
+        ),
+        "top_p": Description(
+            en="Top-p sampling value",
+            zh="Top-p 采样值"
+        ),
+        "repetition_penalty": Description(
+            en="Repetition penalty for synthesis",
+            zh="合成的重复惩罚"
+        ),
+        "temperature": Description(
+            en="Temperature for sampling",
+            zh="采样温度"
+        ),
+        "streaming": Description(
+            en="Enable streaming response",
+            zh="启用流式响应"
+        ),
+        "channels": Description(
+            en="Number of audio channels",
+            zh="音频通道数"
+        ),
+        "rate": Description(
+            en="Sample rate for audio",
+            zh="音频采样率"
+        ),
+        "use_memory_cache": Description(
+            en="Cache encoded references in memory (on/off)",
+            zh="在内存中缓存编码的参考（on/off）"
+        ),
+        "seed": Description(
+            en="Seed for deterministic generation (None for random)",
+            zh="确定性生成的种子（None 表示随机）"
+        ),
+    }
+
 
 class CoquiTTSConfig(I18nMixin):
     """Configuration for Coqui TTS."""
@@ -315,6 +407,7 @@ class TTSConfig(I18nMixin):
         "x_tts",
         "gpt_sovits_tts",
         "fish_api_tts",
+        "fish_tts_local",
         "sherpa_onnx_tts",
     ] = Field(..., alias="tts_model")
 
@@ -328,6 +421,7 @@ class TTSConfig(I18nMixin):
     x_tts: Optional[XTTSConfig] = Field(None, alias="x_tts")
     gpt_sovits_tts: Optional[GPTSoVITSConfig] = Field(None, alias="gpt_sovits")
     fish_api_tts: Optional[FishAPITTSConfig] = Field(None, alias="fish_api_tts")
+    fish_tts_local: Optional[FishTTSLocalConfig] = Field(None, alias="fish_tts_local")
     sherpa_onnx_tts: Optional[SherpaOnnxTTSConfig] = Field(
         None, alias="sherpa_onnx_tts"
     )
@@ -353,6 +447,9 @@ class TTSConfig(I18nMixin):
         ),
         "fish_api_tts": Description(
             en="Configuration for Fish API TTS", zh="Fish API TTS 配置"
+        ),
+        "fish_tts_local": Description(
+            en="Configuration for Fish TTS local", zh="Fish TTS local 配置"
         ),
         "sherpa_onnx_tts": Description(
             en="Configuration for Sherpa Onnx TTS", zh="Sherpa Onnx TTS 配置"
@@ -384,6 +481,8 @@ class TTSConfig(I18nMixin):
             values.gpt_sovits_tts.model_validate(values.gpt_sovits_tts.model_dump())
         elif tts_model == "fish_api_tts" and values.fish_api_tts is not None:
             values.fish_api_tts.model_validate(values.fish_api_tts.model_dump())
+        elif tts_model == "fish_tts_local" and values.fish_tts_local is not None:
+            values.fish_tts_local.model_validate(values.fish_tts_local.model_dump())
         elif tts_model == "sherpa_onnx_tts" and values.sherpa_onnx_tts is not None:
             values.sherpa_onnx_tts.model_validate(values.sherpa_onnx_tts.model_dump())
 

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -1,6 +1,6 @@
 # config_manager/tts.py
 from pydantic import ValidationInfo, Field, model_validator
-from typing import Literal, Optional, List, Dict, ClassVar
+from typing import Literal, Optional, Dict, ClassVar
 from .i18n import I18nMixin, Description
 
 
@@ -230,8 +230,8 @@ class FishTTSLocalConfig(I18nMixin):
     
     api_key: str = Field(..., alias="api_key")
     reference_id: Optional[str] = Field(None, alias="reference_id")
-    reference_audio: Optional[List[str]] = Field(None, alias="reference_audio")
-    reference_text: Optional[List[str]] = Field(None, alias="reference_text")
+    reference_audio: Optional[str] = Field(None, alias="reference_audio")
+    reference_text: Optional[str] = Field(None, alias="reference_text")
     base_url: str = Field("http://127.0.0.1:8080/v1/tts", alias="base_url")
     latency: Literal["normal", "balanced"] = Field("normal", alias="latency")
     audio_format: str = Field("wav", alias="audio_format")

--- a/src/open_llm_vtuber/tts/fishtts_local.py
+++ b/src/open_llm_vtuber/tts/fishtts_local.py
@@ -1,0 +1,118 @@
+import requests
+from loguru import logger
+from .tts_interface import TTSInterface
+import ormsgpack
+from pydub import AudioSegment
+from pydub.playback import play
+from typing import Optional, List, Union
+
+from fish_speech.utils.file import audio_to_bytes, read_ref_text
+from fish_speech.utils.schema import ServeReferenceAudio, ServeTTSRequest
+
+
+class TTSEngine(TTSInterface):
+    def __init__(
+        self,
+        api_url: str = "http://127.0.0.1:8080/v1/tts",
+        reference_id: Optional[str] = None,
+        reference_audio: Optional[List[str]] = None,
+        reference_text: Optional[List[str]] = None,
+        output: str = "generated_audio",
+        audio_format: str = "wav",
+        latency: str = "normal",
+        max_new_tokens: int = 1024,
+        chunk_length: int = 300,
+        top_p: float = 0.8,
+        repetition_penalty: float = 1.1,
+        temperature: float = 0.8,
+        streaming: bool = False,
+        channels: int = 1,
+        rate: int = 44100,
+        use_memory_cache: str = "off",
+        seed: Optional[int] = None,
+        api_key: str = "YOUR_API_KEY",
+    ):
+        self.api_url = api_url
+        self.reference_id = reference_id
+        self.reference_audio = reference_audio or []
+        self.reference_text = reference_text or []
+        self.output = output
+        self.audio_format = audio_format
+        self.latency = latency
+        self.max_new_tokens = max_new_tokens
+        self.chunk_length = chunk_length
+        self.top_p = top_p
+        self.repetition_penalty = repetition_penalty
+        self.temperature = temperature
+        self.streaming = streaming
+        self.channels = channels
+        self.rate = rate
+        self.use_memory_cache = use_memory_cache
+        self.seed = seed
+        self.api_key = api_key
+        self.new_audio_dir = "cache"
+        self.file_extension = audio_format
+
+    def generate_audio(self, text, file_name_no_ext=None):
+        file_name = self.generate_cache_file_name(file_name_no_ext or self.output, self.file_extension)
+
+        # Prepare reference data
+        byte_audios = [audio_to_bytes(ref_audio) for ref_audio in self.reference_audio] if self.reference_audio else []
+        ref_texts = [read_ref_text(ref_text) for ref_text in self.reference_text] if self.reference_text else []
+
+        data = {
+            "text": text,
+            "references": [
+                ServeReferenceAudio(
+                    audio=ref_audio if ref_audio is not None else b"", 
+                    text=ref_text
+                )
+                for ref_text, ref_audio in zip(ref_texts, byte_audios)
+            ],
+            "reference_id": self.reference_id,
+            "format": self.audio_format,
+            "max_new_tokens": self.max_new_tokens,
+            "chunk_length": self.chunk_length,
+            "top_p": self.top_p,
+            "repetition_penalty": self.repetition_penalty,
+            "temperature": self.temperature,
+            "streaming": self.streaming,
+            "use_memory_cache": self.use_memory_cache,
+            "seed": self.seed,
+        }
+
+        pydantic_data = ServeTTSRequest(**data)
+
+        try:
+            response = requests.post(
+                self.api_url,
+                data=ormsgpack.packb(pydantic_data, option=ormsgpack.OPT_SERIALIZE_PYDANTIC),
+                stream=self.streaming,
+                headers={
+                    "authorization": f"Bearer {self.api_key}",
+                    "content-type": "application/msgpack",
+                },
+                timeout=120
+            )
+
+            if response.status_code == 200:
+                if self.streaming:
+                    # For streaming, we'll save the entire response to a file first
+                    with open(file_name, "wb") as audio_file:
+                        for chunk in response.iter_content(chunk_size=1024):
+                            if chunk:
+                                audio_file.write(chunk)
+                else:
+                    with open(file_name, "wb") as audio_file:
+                        audio_file.write(response.content)
+
+                return file_name
+            else:
+                logger.critical(
+                    f"Error: Failed to generate audio. Status code: {response.status_code}\n{response.json()}"
+                )
+                return ""
+
+        except Exception as e:
+            logger.critical(f"Error during TTS request: {str(e)}")
+            return ""

--- a/src/open_llm_vtuber/tts/fishtts_local.py
+++ b/src/open_llm_vtuber/tts/fishtts_local.py
@@ -54,7 +54,7 @@ class TTSEngine(TTSInterface):
         self.file_extension = audio_format
 
     def generate_audio(self, text, file_name_no_ext=None):
-        file_name = self.generate_cache_file_name(file_name_no_ext or self.output, self.file_extension)
+        file_name = self.generate_cache_file_name(file_name_no_ext, self.file_extension)
 
         # Prepare reference data
         byte_audios = [audio_to_bytes(ref_audio) for ref_audio in self.reference_audio] if self.reference_audio else []

--- a/src/open_llm_vtuber/tts/fishtts_local.py
+++ b/src/open_llm_vtuber/tts/fishtts_local.py
@@ -57,8 +57,8 @@ class TTSEngine(TTSInterface):
         file_name = self.generate_cache_file_name(file_name_no_ext, self.file_extension)
 
         # Prepare reference data
-        byte_audios = [audio_to_bytes(ref_audio) for ref_audio in self.reference_audio] if self.reference_audio else []
-        ref_texts = [read_ref_text(ref_text) for ref_text in self.reference_text] if self.reference_text else []
+        byte_audios = [audio_to_bytes(ref_audio) for ref_audio in [self.reference_audio]] if [self.reference_audio] else []
+        ref_texts = [read_ref_text(ref_text) for ref_text in [self.reference_text]] if [self.reference_text] else []
 
         data = {
             "text": text,
@@ -94,7 +94,7 @@ class TTSEngine(TTSInterface):
                 },
                 timeout=120
             )
-
+            
             if response.status_code == 200:
                 if self.streaming:
                     # For streaming, we'll save the entire response to a file first
@@ -108,11 +108,11 @@ class TTSEngine(TTSInterface):
 
                 return file_name
             else:
-                logger.critical(
+                logger.error(
                     f"Error: Failed to generate audio. Status code: {response.status_code}\n{response.json()}"
                 )
                 return ""
 
         except Exception as e:
-            logger.critical(f"Error during TTS request: {str(e)}")
+            logger.error(f"Error during TTS request: {str(e)}")
             return ""

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -108,6 +108,28 @@ class TTSFactory:
                 latency=kwargs.get("latency"),
                 base_url=kwargs.get("base_url"),
             )
+        elif engine_type == "fish_tts_local":
+            from .fishtts_local import TTSEngine as FishTTSEngine
+
+            return FishTTSEngine(
+                api_url=kwargs.get("base_url", "http://127.0.0.1:8080/v1/tts"),
+                reference_id=kwargs.get("reference_id", None),
+                reference_audio=kwargs.get("reference_audio", None),
+                reference_text=kwargs.get("reference_text", None),
+                audio_format=kwargs.get("audio_format", "wav"),
+                latency=kwargs.get("latency", "normal"),
+                max_new_tokens=kwargs.get("latency", 1024),
+                chunk_length=kwargs.get("chunk_length", 300),
+                top_p=kwargs.get("top_p", 0.8),
+                repetition_penalty=kwargs.get("repetition_penalty", 1.1),
+                temperature=kwargs.get("temperature", 0.8),
+                streaming=kwargs.get("streaming", False),
+                channels=kwargs.get("channels", 1),
+                rate=kwargs.get("rate", 44100),
+                use_memory_cache=kwargs.get("use_memory_cache", "off"),
+                seed=kwargs.get("seed", None),
+                api_key=kwargs.get("api_key", "YOUR_API_KEY"),
+            )
         elif engine_type == "sherpa_onnx_tts":
             from .sherpa_onnx_tts import TTSEngine as SherpaOnnxTTSEngine
 

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -110,15 +110,15 @@ class TTSFactory:
             )
         elif engine_type == "fish_tts_local":
             from .fishtts_local import TTSEngine as FishTTSEngine
-
+            
             return FishTTSEngine(
-                api_url=kwargs.get("base_url", "http://127.0.0.1:8080/v1/tts"),
+                api_url=kwargs.get("api_url", "http://127.0.0.1:8080/v1/tts"),
                 reference_id=kwargs.get("reference_id", None),
                 reference_audio=kwargs.get("reference_audio", None),
                 reference_text=kwargs.get("reference_text", None),
                 audio_format=kwargs.get("audio_format", "wav"),
                 latency=kwargs.get("latency", "normal"),
-                max_new_tokens=kwargs.get("latency", 1024),
+                max_new_tokens=kwargs.get("max_new_tokens", 1024),
                 chunk_length=kwargs.get("chunk_length", 300),
                 top_p=kwargs.get("top_p", 0.8),
                 repetition_penalty=kwargs.get("repetition_penalty", 1.1),


### PR DESCRIPTION
This pull request adds local-hosted FishTTS (including s1-audio) to the available TTS systems. It requires the fish-audio package to be first installed with pip from their repo.

Local-hosted FishTTS, besides being private, adds a buff to voice-clone any voice in multiple world languages provided a sample and a reference text in the sample, which is especially useful for customized character creation.