### PR TITLE
feat: add FireredASR support in sherpa_onnx_asr

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -220,7 +220,7 @@ character_config:
     # 文档：https://k2-fsa.github.io/sherpa/onnx/index.html
     # ASR 模型下载：https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
     sherpa_onnx_asr:
-      model_type: 'sense_voice' # 'transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'whisper', 'tdnn_ctc'
+      model_type: 'sense_voice' # 'transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'whisper', 'tdnn_ctc', 'sense_voice', 'fire_red_asr'
       # 根据 model_type 选择以下其中一个：
       # --- 对于 model_type: 'transducer' ---
       # encoder: ''        # 编码器模型路径（例如 'path/to/encoder.onnx'）
@@ -228,6 +228,9 @@ character_config:
       # joiner: ''         # 连接器模型路径（例如 'path/to/joiner.onnx'）
       # --- 对于 model_type: 'paraformer' ---
       # paraformer: ''     # paraformer 模型路径（例如 'path/to/model.onnx'）
+      # --- 对于 model_type: 'fire_red_asr' (FireredASR - 高性能中英文识别，支持方言) ---
+      # fire_red_asr_encoder: ''    # 编码器模型路径（例如 'path/to/encoder.onnx'）
+      # fire_red_asr_decoder: ''    # 解码器模型路径（例如 'path/to/decoder.onnx'）
       # --- 对于 model_type: 'nemo_ctc' ---
       # nemo_ctc: ''        # NeMo CTC 模型路径（例如 'path/to/model.onnx'）
       # --- 对于 model_type: 'wenet_ctc' ---

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -222,7 +222,7 @@ character_config:
     # documentation: https://k2-fsa.github.io/sherpa/onnx/index.html
     # ASR models download: https://github.com/k2-fsa/sherpa-onnx/releases/tag/asr-models
     sherpa_onnx_asr:
-      model_type: 'sense_voice' # 'transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'whisper', 'tdnn_ctc'
+      model_type: 'sense_voice' # 'transducer', 'paraformer', 'nemo_ctc', 'wenet_ctc', 'whisper', 'tdnn_ctc', 'sense_voice', 'fire_red_asr'
       #  Choose only ONE of the following, depending on the model_type:
       # --- For model_type: 'transducer' ---
       # encoder: ''        # Path to the encoder model (e.g., 'path/to/encoder.onnx')
@@ -230,6 +230,9 @@ character_config:
       # joiner: ''         # Path to the joiner model (e.g., 'path/to/joiner.onnx')
       # --- For model_type: 'paraformer' ---
       # paraformer: ''     # Path to the paraformer model (e.g., 'path/to/model.onnx')
+      # --- For model_type: 'fire_red_asr' (FireredASR - High-performance Chinese & English ASR with dialect support) ---
+      # fire_red_asr_encoder: ''    # Path to the encoder model (e.g., 'path/to/encoder.onnx')
+      # fire_red_asr_decoder: ''    # Path to the decoder model (e.g., 'path/to/decoder.onnx')
       # --- For model_type: 'nemo_ctc' ---
       # nemo_ctc: ''        # Path to the NeMo CTC model (e.g., 'path/to/model.onnx')
       # --- For model_type: 'wenet_ctc' ---

--- a/src/open_llm_vtuber/asr/sherpa_onnx_asr.py
+++ b/src/open_llm_vtuber/asr/sherpa_onnx_asr.py
@@ -10,7 +10,7 @@ import onnxruntime
 class VoiceRecognition(ASRInterface):
     def __init__(
         self,
-        model_type: str = "paraformer",  # or "transducer", "nemo_ctc", "wenet_ctc", "whisper", "tdnn_ctc", "sense_voice"
+        model_type: str = "paraformer",  # or "transducer", "nemo_ctc", "wenet_ctc", "whisper", "tdnn_ctc", "sense_voice", "fire_red_asr"
         encoder: str = None,  # Path to the encoder model, used with transducer
         decoder: str = None,  # Path to the decoder model, used with transducer
         joiner: str = None,  # Path to the joiner model, used with transducer
@@ -21,6 +21,8 @@ class VoiceRecognition(ASRInterface):
         whisper_encoder: str = None,  # Path to whisper encoder model
         whisper_decoder: str = None,  # Path to whisper decoder model
         sense_voice: str = None,  # Path to the model.onnx from SenseVoice
+        fire_red_asr_encoder: str = None,  # Path to FireRedASR encoder model
+        fire_red_asr_decoder: str = None,  # Path to FireRedASR decoder model
         tokens: str = None,  # Path to tokens.txt
         hotwords_file: str = "",  # Path to hotwords file
         hotwords_score: float = 1.5,  # Hotwords score
@@ -49,6 +51,8 @@ class VoiceRecognition(ASRInterface):
         self.whisper_encoder = whisper_encoder
         self.whisper_decoder = whisper_decoder
         self.sense_voice: str = sense_voice
+        self.fire_red_asr_encoder = fire_red_asr_encoder
+        self.fire_red_asr_decoder = fire_red_asr_decoder
         self.tokens = tokens
         self.hotwords_file = hotwords_file
         self.hotwords_score = hotwords_score
@@ -190,6 +194,16 @@ class VoiceRecognition(ASRInterface):
                 tokens=self.tokens,
                 num_threads=self.num_threads,
                 use_itn=self.use_itn,
+                debug=self.debug,
+                provider=self.provider,
+            )
+        elif self.model_type == "fire_red_asr":
+            recognizer = sherpa_onnx.OfflineRecognizer.from_fire_red_asr(
+                encoder=self.fire_red_asr_encoder,
+                decoder=self.fire_red_asr_decoder,
+                tokens=self.tokens,
+                num_threads=self.num_threads,
+                decoding_method=self.decoding_method,
                 debug=self.debug,
                 provider=self.provider,
             )

--- a/src/open_llm_vtuber/config_manager/asr.py
+++ b/src/open_llm_vtuber/config_manager/asr.py
@@ -192,6 +192,7 @@ class SherpaOnnxASRConfig(I18nMixin):
         "whisper",
         "tdnn_ctc",
         "sense_voice",
+        "fire_red_asr",
     ] = Field(..., alias="model_type")
     encoder: Optional[str] = Field(None, alias="encoder")
     decoder: Optional[str] = Field(None, alias="decoder")
@@ -203,6 +204,8 @@ class SherpaOnnxASRConfig(I18nMixin):
     whisper_encoder: Optional[str] = Field(None, alias="whisper_encoder")
     whisper_decoder: Optional[str] = Field(None, alias="whisper_decoder")
     sense_voice: Optional[str] = Field(None, alias="sense_voice")
+    fire_red_asr_encoder: Optional[str] = Field(None, alias="fire_red_asr_encoder")
+    fire_red_asr_decoder: Optional[str] = Field(None, alias="fire_red_asr_decoder")
     tokens: str = Field(..., alias="tokens")
     num_threads: int = Field(4, alias="num_threads")
     use_itn: bool = Field(True, alias="use_itn")
@@ -238,6 +241,12 @@ class SherpaOnnxASRConfig(I18nMixin):
         ),
         "sense_voice": Description(
             en="Path to SenseVoice model", zh="SenseVoice 模型路径"
+        ),
+        "fire_red_asr_encoder": Description(
+            en="Path to FireredASR encoder model", zh="FireredASR 编码器模型路径"
+        ),
+        "fire_red_asr_decoder": Description(
+            en="Path to FireredASR decoder model", zh="FireredASR 解码器模型路径"
         ),
         "tokens": Description(en="Path to tokens file", zh="词元文件路径"),
         "num_threads": Description(en="Number of threads to use", zh="使用的线程数"),
@@ -288,6 +297,11 @@ class SherpaOnnxASRConfig(I18nMixin):
             if not all([values.sense_voice, values.tokens]):
                 raise ValueError(
                     "sense_voice and tokens must be provided for sense_voice model type"
+                )
+        elif model_type == "fire_red_asr":
+            if not all([values.fire_red_asr_encoder, values.fire_red_asr_decoder, values.tokens]):
+                raise ValueError(
+                    "fire_red_asr_encoder, fire_red_asr_decoder, and tokens must be provided for fire_red_asr model type"
                 )
 
         return values


### PR DESCRIPTION
Closes #243

## 📝 PR 描述

本 PR 为 sherpa-onnx ASR 添加了 FireredASR模型支持，提供高性能的中英文混合语音识别能力。

## ✨ 新增功能

- **FireredASR 模型支持**: 在 `sherpa_onnx_asr` 中新增 `fire_red_asr` 模型类型
- **中英文混合识别**: 专门针对中英文混合场景优化，支持普通话及多种方言（川普、津普、豫普等）
- **量化模型支持**: 同时支持 fp16 和 int8 量化版本，在 CPU 上也能获得优秀性能

## 🔧 主要更改

### 1. ASR 实现 ([`src/open_llm_vtuber/asr/sherpa_onnx_asr.py`](src/open_llm_vtuber/asr/sherpa_onnx_asr.py))

- 添加 `fire_red_asr_encoder` 和 `fire_red_asr_decoder` 参数
- 在 `_create_recognizer()` 方法中实现 `fire_red_asr` 分支
- 使用 `sherpa_onnx.OfflineRecognizer.from_fire_red_asr()` API

### 2. 配置验证 ([`src/open_llm_vtuber/config_manager/asr.py`](src/open_llm_vtuber/config_manager/asr.py))

- 在 `SherpaOnnxASRConfig` 中添加 `fire_red_asr` 到 `model_type` 枚举
- 添加 `fire_red_asr_encoder` 和 `fire_red_asr_decoder` 字段及验证逻辑
- 添加详细的字段描述和文档

### 3. 配置模板更新

- **中文模板** ([`config_templates/conf.ZH.default.yaml`](config_templates/conf.ZH.default.yaml)): 添加 FireredASR 配置示例和中文说明
- **英文模板** ([`config_templates/conf.default.yaml`](config_templates/conf.default.yaml)): 添加 FireredASR 配置示例和英文说明

## 📦 模型下载

用户可通过以下方式下载 FireredASR 模型：

```bash
# int8 版本（推荐 CPU 使用，1.74 GB）
uv run hf download csukuangfj/sherpa-onnx-fire-red-asr-large-zh_en-2025-02-16

# fp16 版本（2.34 GB）
uv run hf download csukuangfj/sherpa-onnx-fire-red-asr-large-zh_en-fp16-2025-02-16