### PR TITLE
Fix CoquiTTS crash on special characters and punctuation-only text

### DIFF
--- a/src/open_llm_vtuber/tts/coqui_tts.py
+++ b/src/open_llm_vtuber/tts/coqui_tts.py
@@ -86,18 +86,17 @@ class TTSEngine(TTSInterface):
         """
         # Sanitize: strip and check for pronounceable content
         text = text.strip()
+        output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
+
         if not text or not any(c.isalnum() for c in text):
             logger.warning(
                 f"coqui_tts: Skipping non-pronounceable text: "
                 f"'{text[:100]}{'...' if len(text) > 100 else ''}'"
             )
-            output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
             self._generate_silent_wav(output_path)
             return output_path
 
         try:
-            # Generate output path
-            output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
 
             # Generate speech based on speaker mode
             if self.is_multi_speaker and self.speaker_wav:

--- a/src/open_llm_vtuber/tts/coqui_tts.py
+++ b/src/open_llm_vtuber/tts/coqui_tts.py
@@ -57,8 +57,11 @@ class TTSEngine(TTSInterface):
             raise RuntimeError(f"Failed to initialize CoquiTTS model: {str(e)}")
 
     _SAMPLE_WIDTH_BYTES = 2  # 16-bit audio
+    _DEFAULT_SILENCE_DURATION_S = 0.1
 
-    def _generate_silent_wav(self, output_path: str, duration: float = 0.1) -> None:
+    def _generate_silent_wav(
+        self, output_path: str, duration: float = _DEFAULT_SILENCE_DURATION_S
+    ) -> None:
         """Generate a short silent WAV file matching the model's sample rate.
 
         Args:
@@ -97,7 +100,6 @@ class TTSEngine(TTSInterface):
             return output_path
 
         try:
-
             # Generate speech based on speaker mode
             if self.is_multi_speaker and self.speaker_wav:
                 # Multi-speaker mode with voice cloning

--- a/src/open_llm_vtuber/tts/coqui_tts.py
+++ b/src/open_llm_vtuber/tts/coqui_tts.py
@@ -67,6 +67,9 @@ class TTSEngine(TTSInterface):
         Args:
             output_path: The path to save the output WAV file.
             duration: The duration of the silence in seconds.
+
+        Returns:
+            None.
         """
         sample_rate = self.tts.synthesizer.output_sample_rate
         num_frames = int(sample_rate * duration)
@@ -87,19 +90,19 @@ class TTSEngine(TTSInterface):
         Returns:
             Path to generated audio file
         """
-        # Sanitize: strip and check for pronounceable content
-        text = text.strip()
-        output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
-
-        if not text or not any(c.isalnum() for c in text):
-            logger.warning(
-                f"coqui_tts: Skipping non-pronounceable text: "
-                f"'{text[:100]}{'...' if len(text) > 100 else ''}'"
-            )
-            self._generate_silent_wav(output_path)
-            return output_path
-
         try:
+            # Sanitize: strip and check for pronounceable content
+            text = text.strip()
+            output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
+
+            if not text or not any(c.isalnum() for c in text):
+                logger.warning(
+                    f"coqui_tts: Skipping non-pronounceable text: "
+                    f"'{text[:100]}{'...' if len(text) > 100 else ''}'"
+                )
+                self._generate_silent_wav(output_path)
+                return output_path
+
             # Generate speech based on speaker mode
             if self.is_multi_speaker and self.speaker_wav:
                 # Multi-speaker mode with voice cloning


### PR DESCRIPTION
## Description

Fix CoquiTTS crashing when receiving non-pronounceable text such as special characters (e.g. emojis, control characters) or punctuation-only strings (e.g. `...`).

### Changes
- Added text validation at the beginning of `generate_audio()` in `coqui_tts.py`
- If text is empty after stripping or contains no alphanumeric characters, return a short silent WAV file instead of passing it to CoquiTTS
- Added `_generate_silent_wav()` helper method to generate minimal silent audio

### How it works
The existing `remove_special_characters()` filter keeps Letters/Numbers/Punctuation/Whitespace, but punctuation-only text (e.g. `...`) still passes through and causes CoquiTTS to throw an error. This fix adds a final check: if no letter or number is present in the text, skip TTS synthesis and return silence.

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of text-to-speech generation by gracefully handling empty or non-pronounceable text inputs, generating silent audio output instead of potential failures.
  * Added input validation to sanitize text before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->