### PR TITLE
Add default_character_config to set default character by filename

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -10,6 +10,9 @@ system_config:
   host: 'localhost' # 服务器监听的地址，'0.0.0.0' 表示监听所有网络接口；如果需要安全，可以使用 '127.0.0.1'（仅本地访问）
   port: 12393 # 服务器监听的端口
   config_alts_dir: 'characters' # 用于存放替代配置的目录
+  # 设置 config_alts_dir 中的角色配置文件名作为默认角色。
+  # 例如 'zh_米粒.yaml'。留空则使用下方的 character_config。
+  default_character_config: ''
   tool_prompts: # 要插入到角色提示词中的工具提示词
     live2d_expression_prompt: 'live2d_expression_prompt' # 将追加到系统提示末尾，让 LLM（大型语言模型）包含控制面部表情的关键字。支持的关键字将自动加载到 `[<insert_emomap_keys>]` 的位置。
     # 启用 think_tag_prompt 可让不具备思考输出的 LLM 也能展示内心想法、心理活动和动作（以括号形式呈现），但不会进行语音合成。更多详情请参考 think_tag_prompt。

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -5,6 +5,9 @@ system_config:
   port: 12393
   # New setting for alternative configurations
   config_alts_dir: 'characters'
+  # Set a character config filename from config_alts_dir to use as the default character.
+  # e.g. 'zh_米粒.yaml'. Leave empty to use the character_config below.
+  default_character_config: ''
   # Tool prompts that will be appended to the persona prompt
   tool_prompts:
     # This will be appended to the end of system prompt to let LLM include keywords to control facial expressions.

--- a/run_server.py
+++ b/run_server.py
@@ -141,8 +141,13 @@ def run(console_log_level: str):
     # Apply default character config override if specified
     default_char = config.system_config.default_character_config
     if default_char:
-        alt_path = os.path.join(config.system_config.config_alts_dir, default_char)
-        if not os.path.exists(alt_path):
+        characters_dir = config.system_config.config_alts_dir
+        alt_path = os.path.normpath(os.path.join(characters_dir, default_char))
+        if not alt_path.startswith(os.path.normpath(characters_dir)):
+            logger.error(
+                f"Invalid default character config path (path traversal?): {alt_path}"
+            )
+        elif not os.path.exists(alt_path):
             logger.error(f"Default character config not found: {alt_path}")
         else:
             alt_data = read_yaml(alt_path).get("character_config")

--- a/run_server.py
+++ b/run_server.py
@@ -11,7 +11,7 @@ from loguru import logger
 from upgrade_codes.upgrade_manager import UpgradeManager
 
 from src.open_llm_vtuber.server import WebSocketServer
-from src.open_llm_vtuber.config_manager import Config, read_yaml, validate_config
+from src.open_llm_vtuber.config_manager import Config, read_yaml, validate_config, deep_merge
 
 os.environ["HF_HOME"] = str(Path(__file__).parent / "models")
 os.environ["MODELSCOPE_CACHE"] = str(Path(__file__).parent / "models")
@@ -137,6 +137,25 @@ def run(console_log_level: str):
 
     # Load configurations from yaml file
     config: Config = validate_config(read_yaml("conf.yaml"))
+
+    # Apply default character config override if specified
+    default_char = config.system_config.default_character_config
+    if default_char:
+        alt_path = os.path.join(config.system_config.config_alts_dir, default_char)
+        if not os.path.exists(alt_path):
+            logger.error(f"Default character config not found: {alt_path}")
+        else:
+            alt_data = read_yaml(alt_path).get("character_config")
+            if alt_data:
+                merged = deep_merge(config.character_config.model_dump(), alt_data)
+                config = validate_config({
+                    "system_config": config.system_config.model_dump(),
+                    "character_config": merged,
+                })
+                logger.info(f"Applied default character config: {default_char}")
+            else:
+                logger.warning(f"No character_config found in {alt_path}")
+
     server_config = config.system_config
 
     if server_config.enable_proxy:

--- a/run_server.py
+++ b/run_server.py
@@ -160,15 +160,9 @@ def run(console_log_level: str):
                         config.character_config.model_dump(by_alias=True),
                         alt_data,
                     )
-                    config = validate_config(
-                        {
-                            "system_config": config.system_config.model_dump(
-                                by_alias=True
-                            ),
-                            "character_config": merged,
-                            "live_config": config.live_config.model_dump(by_alias=True),
-                        }
-                    )
+                    new_config_data = config.model_dump(by_alias=True)
+                    new_config_data["character_config"] = merged
+                    config = validate_config(new_config_data)
                     logger.info(f"Applied default character config: {default_char}")
                 else:
                     logger.warning(f"No character_config found in {alt_path}")

--- a/run_server.py
+++ b/run_server.py
@@ -11,7 +11,12 @@ from loguru import logger
 from upgrade_codes.upgrade_manager import UpgradeManager
 
 from src.open_llm_vtuber.server import WebSocketServer
-from src.open_llm_vtuber.config_manager import Config, read_yaml, validate_config, deep_merge
+from src.open_llm_vtuber.config_manager import (
+    Config,
+    read_yaml,
+    validate_config,
+    deep_merge,
+)
 
 os.environ["HF_HOME"] = str(Path(__file__).parent / "models")
 os.environ["MODELSCOPE_CACHE"] = str(Path(__file__).parent / "models")
@@ -147,9 +152,7 @@ def run(console_log_level: str):
             alt_path.relative_to(characters_dir)
 
             if not alt_path.is_file():
-                logger.error(
-                    f"Default character config not found: {alt_path}"
-                )
+                logger.error(f"Default character config not found: {alt_path}")
             else:
                 alt_data = read_yaml(str(alt_path)).get("character_config")
                 if alt_data:
@@ -157,22 +160,18 @@ def run(console_log_level: str):
                         config.character_config.model_dump(by_alias=True),
                         alt_data,
                     )
-                    config = validate_config({
-                        "system_config": config.system_config.model_dump(
-                            by_alias=True
-                        ),
-                        "character_config": merged,
-                        "live_config": config.live_config.model_dump(
-                            by_alias=True
-                        ),
-                    })
-                    logger.info(
-                        f"Applied default character config: {default_char}"
+                    config = validate_config(
+                        {
+                            "system_config": config.system_config.model_dump(
+                                by_alias=True
+                            ),
+                            "character_config": merged,
+                            "live_config": config.live_config.model_dump(by_alias=True),
+                        }
                     )
+                    logger.info(f"Applied default character config: {default_char}")
                 else:
-                    logger.warning(
-                        f"No character_config found in {alt_path}"
-                    )
+                    logger.warning(f"No character_config found in {alt_path}")
         except ValueError:
             logger.error(
                 f"Invalid default character config path (path traversal attempt): {default_char}"

--- a/src/open_llm_vtuber/config_manager/__init__.py
+++ b/src/open_llm_vtuber/config_manager/__init__.py
@@ -62,6 +62,7 @@ from .utils import (
     save_config,
     scan_config_alts_directory,
     scan_bg_directory,
+    deep_merge,
 )
 
 __all__ = [
@@ -122,4 +123,5 @@ __all__ = [
     "save_config",
     "scan_config_alts_directory",
     "scan_bg_directory",
+    "deep_merge",
 ]

--- a/src/open_llm_vtuber/config_manager/system.py
+++ b/src/open_llm_vtuber/config_manager/system.py
@@ -13,6 +13,7 @@ class SystemConfig(I18nMixin):
     config_alts_dir: str = Field(..., alias="config_alts_dir")
     tool_prompts: Dict[str, str] = Field(..., alias="tool_prompts")
     enable_proxy: bool = Field(False, alias="enable_proxy")
+    default_character_config: str = Field("", alias="default_character_config")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "conf_version": Description(en="Configuration version", zh="配置文件版本"),
@@ -28,6 +29,10 @@ class SystemConfig(I18nMixin):
         "enable_proxy": Description(
             en="Enable proxy mode for multiple clients",
             zh="启用代理模式以支持多个客户端使用一个 ws 连接",
+        ),
+        "default_character_config": Description(
+            en="Filename of a character config in config_alts_dir to use as default (e.g. 'zh_米粒.yaml'). Leave empty to use the character_config in conf.yaml.",
+            zh="config_alts_dir 中用作默认角色的配置文件名（例如 'zh_米粒.yaml'）。留空则使用 conf.yaml 中的 character_config。",
         ),
     }
 

--- a/src/open_llm_vtuber/config_manager/utils.py
+++ b/src/open_llm_vtuber/config_manager/utils.py
@@ -171,9 +171,15 @@ def scan_config_alts_directory(config_alts_dir: str) -> list[dict]:
     return config_files
 
 
-def deep_merge(dict1: dict, dict2: dict) -> dict:
-    """
-    Recursively merges dict2 into dict1, prioritizing values from dict2.
+def deep_merge(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merges dict2 into dict1, prioritizing values from dict2.
+
+    Args:
+        dict1: The base dictionary.
+        dict2: The dictionary to merge into the base dictionary.
+
+    Returns:
+        The merged dictionary.
     """
     result = dict1.copy()
     for key, value in dict2.items():

--- a/src/open_llm_vtuber/config_manager/utils.py
+++ b/src/open_llm_vtuber/config_manager/utils.py
@@ -171,6 +171,19 @@ def scan_config_alts_directory(config_alts_dir: str) -> list[dict]:
     return config_files
 
 
+def deep_merge(dict1: dict, dict2: dict) -> dict:
+    """
+    Recursively merges dict2 into dict1, prioritizing values from dict2.
+    """
+    result = dict1.copy()
+    for key, value in dict2.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
 def scan_bg_directory() -> list[str]:
     bg_files = []
     bg_dir = "backgrounds"

--- a/src/open_llm_vtuber/service_context.py
+++ b/src/open_llm_vtuber/service_context.py
@@ -35,6 +35,7 @@ from .config_manager import (
     TranslatorConfig,
     read_yaml,
     validate_config,
+    deep_merge,
 )
 
 
@@ -557,16 +558,3 @@ class ServiceContext:
                 )
             )
             raise e
-
-
-def deep_merge(dict1, dict2):
-    """
-    Recursively merges dict2 into dict1, prioritizing values from dict2.
-    """
-    result = dict1.copy()
-    for key, value in dict2.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = deep_merge(result[key], value)
-        else:
-            result[key] = value
-    return result


### PR DESCRIPTION
## Description

Allow setting the default character by specifying a filename from the `characters/` directory in `conf.yaml`, instead of having to copy the entire `character_config` section.

### Changes
- Added `default_character_config` field to `SystemConfig` (default: empty string)
- In `run_server.py`, if `default_character_config` is set, load the specified character file and deep-merge it over the base `character_config`
- Moved `deep_merge()` from `service_context.py` to `config_manager/utils.py` so it can be shared by both `run_server.py` and `service_context.py`
- Updated config templates (`conf.default.yaml`, `conf.ZH.default.yaml`) with the new field and comments

### Usage
```yaml
system_config:
  default_character_config: 'zh_米粒.yaml'  # filename in characters/ dir
```

Leave empty to use the inline `character_config` as before.

Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * A new system configuration option enables you to specify a default character configuration file from your alternatives directory. The specified file is automatically loaded and merged with your main character configuration when the server starts, providing a convenient way to manage multiple character configurations without directly editing the primary configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->