### PR TITLE
fix: prevent ellipsis-only AI reply and missing voice when user speaks continuously

### DIFF
--- a/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
+++ b/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
@@ -28,6 +28,7 @@ from ...mcpp.tool_manager import ToolManager
 from ...mcpp.json_detector import StreamJSONDetector
 from ...mcpp.types import ToolCallObject
 from ...mcpp.tool_executor import ToolExecutor
+from ...conversations.conversation_utils import is_substantive_response
 
 
 class BasicMemoryAgent(AgentInterface):
@@ -123,6 +124,11 @@ class BasicMemoryAgent(AgentInterface):
         if self.interrupt_method == "user":
             system = f"{system}\n\nIf you received `[interrupted by user]` signal, you were interrupted."
 
+        system = (
+            f"{system}\n\n"
+            "Do not respond with only ellipsis (...) or punctuation. "
+            "For brief acknowledgments use a short spoken phrase (e.g. 好的, 嗯, Okay)."
+        )
         self._system = system
 
     def _add_message(
@@ -193,23 +199,27 @@ class BasicMemoryAgent(AgentInterface):
         logger.info(f"Loaded {len(self._memory)} messages from history.")
 
     def handle_interrupt(self, heard_response: str) -> None:
-        """Handle user interruption."""
+        """Handle user interruption.
+
+        Updates memory with the partial assistant response (if any) without appending
+        "...", to avoid polluting context and priming the model to output ellipsis.
+        """
         if self._interrupt_handled:
             return
 
         self._interrupt_handled = True
 
+        heard = (heard_response or "").strip()
         if self._memory and self._memory[-1]["role"] == "assistant":
-            if not self._memory[-1]["content"].endswith("..."):
-                self._memory[-1]["content"] = heard_response + "..."
-            else:
-                self._memory[-1]["content"] = heard_response + "..."
+            self._memory[-1]["content"] = (
+                heard if heard else self._memory[-1]["content"]
+            )
         else:
-            if heard_response:
+            if heard:
                 self._memory.append(
                     {
                         "role": "assistant",
-                        "content": heard_response + "...",
+                        "content": heard,
                     }
                 )
 
@@ -656,7 +666,7 @@ class BasicMemoryAgent(AgentInterface):
                     if text_chunk:
                         yield text_chunk
                         complete_response += text_chunk
-                if complete_response:
+                if complete_response and is_substantive_response(complete_response):
                     self._add_message(complete_response, "assistant")
 
         return chat_with_memory

--- a/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
+++ b/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
@@ -35,6 +35,7 @@ class BasicMemoryAgent(AgentInterface):
     """Agent with basic chat memory and tool calling support."""
 
     _system: str = "You are a helpful assistant."
+    _INTERRUPTED_SIGNAL: str = "[Interrupted by user]"
 
     def __init__(
         self,
@@ -122,7 +123,10 @@ class BasicMemoryAgent(AgentInterface):
         logger.debug(f"Memory Agent: Setting system prompt: '''{system}'''")
 
         if self.interrupt_method == "user":
-            system = f"{system}\n\nIf you received `[interrupted by user]` signal, you were interrupted."
+            system = (
+                f"{system}\n\nIf you received `{self._INTERRUPTED_SIGNAL}` signal, "
+                "you were interrupted."
+            )
 
         system = (
             f"{system}\n\n"
@@ -210,6 +214,8 @@ class BasicMemoryAgent(AgentInterface):
         self._interrupt_handled = True
 
         heard = (heard_response or "").strip()
+        if heard and not is_substantive_response(heard):
+            heard = ""
         if self._memory and self._memory[-1]["role"] == "assistant":
             self._memory[-1]["content"] = (
                 heard if heard else self._memory[-1]["content"]
@@ -227,7 +233,7 @@ class BasicMemoryAgent(AgentInterface):
         self._memory.append(
             {
                 "role": interrupt_role,
-                "content": "[Interrupted by user]",
+                "content": self._INTERRUPTED_SIGNAL,
             }
         )
         logger.info(f"Handled interrupt with role '{interrupt_role}'.")

--- a/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
+++ b/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
@@ -216,18 +216,8 @@ class BasicMemoryAgent(AgentInterface):
         heard = (heard_response or "").strip()
         if heard and not is_substantive_response(heard):
             heard = ""
-        if self._memory and self._memory[-1]["role"] == "assistant":
-            self._memory[-1]["content"] = (
-                heard if heard else self._memory[-1]["content"]
-            )
-        else:
-            if heard:
-                self._memory.append(
-                    {
-                        "role": "assistant",
-                        "content": heard,
-                    }
-                )
+        if heard:
+            self._add_message(heard, "assistant")
 
         interrupt_role = "system" if self.interrupt_method == "system" else "user"
         self._memory.append(

--- a/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
+++ b/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
@@ -127,7 +127,7 @@ class BasicMemoryAgent(AgentInterface):
         system = (
             f"{system}\n\n"
             "Do not respond with only ellipsis (...) or punctuation. "
-            "For brief acknowledgments use a short spoken phrase (e.g. 好的, 嗯, Okay)."
+            "For brief acknowledgments use a short spoken phrase appropriate to the conversation language."
         )
         self._system = system
 
@@ -372,7 +372,9 @@ class BasicMemoryAgent(AgentInterface):
                             if c["type"] == "text"
                         ]
                     ).strip()
-                    if assistant_text_for_memory:
+                    if assistant_text_for_memory and is_substantive_response(
+                        assistant_text_for_memory
+                    ):
                         self._add_message(assistant_text_for_memory, "assistant")
 
                 tool_results_for_llm = []
@@ -406,7 +408,7 @@ class BasicMemoryAgent(AgentInterface):
                 # stop_reason = None
                 continue
             else:
-                if current_turn_text:
+                if current_turn_text and is_substantive_response(current_turn_text):
                     self._add_message(current_turn_text, "assistant")
                 return
 
@@ -507,7 +509,8 @@ class BasicMemoryAgent(AgentInterface):
 
             if detected_prompt_json:
                 logger.info("Processing tools detected via prompt mode JSON.")
-                self._add_message(current_turn_text, "assistant")
+                if current_turn_text and is_substantive_response(current_turn_text):
+                    self._add_message(current_turn_text, "assistant")
 
                 parsed_tools = self._tool_executor.process_tool_from_prompt_json(
                     detected_prompt_json
@@ -551,7 +554,7 @@ class BasicMemoryAgent(AgentInterface):
 
             elif pending_tool_calls and assistant_message_for_api:
                 messages.append(assistant_message_for_api)
-                if current_turn_text:
+                if current_turn_text and is_substantive_response(current_turn_text):
                     self._add_message(current_turn_text, "assistant")
 
                 tool_results_for_llm = []
@@ -584,7 +587,7 @@ class BasicMemoryAgent(AgentInterface):
                 continue
 
             else:
-                if current_turn_text:
+                if current_turn_text and is_substantive_response(current_turn_text):
                     self._add_message(current_turn_text, "assistant")
                 return
 

--- a/src/open_llm_vtuber/conversations/conversation_utils.py
+++ b/src/open_llm_vtuber/conversations/conversation_utils.py
@@ -15,6 +15,27 @@ from ..live2d_model import Live2dModel
 from ..tts.tts_interface import TTSInterface
 from ..utils.stream_audio import prepare_audio_payload
 
+# Regex used to detect "substantive" text (same as tts_manager empty check).
+# If after removing these chars the string is empty, we treat as non-substantive.
+_SUBSTANTIVE_STRIP_RE = re.compile(r"[\s.,!?，。！？\'\"』」）】\s]+")
+
+
+def is_substantive_response(text: str) -> bool:
+    """Return True if text has substantive content (not only punctuation/whitespace/ellipsis).
+
+    Used to avoid storing or treating ellipsis-only model replies as real responses,
+    and to align with tts_manager's empty-TTS-text behavior.
+
+    Args:
+        text: The response text to check.
+
+    Returns:
+        True if there is at least one character left after removing punctuation/whitespace.
+    """
+    if not text or not text.strip():
+        return False
+    return len(_SUBSTANTIVE_STRIP_RE.sub("", text)) > 0
+
 
 # Convert class methods to standalone functions
 def create_batch_input(

--- a/src/open_llm_vtuber/conversations/conversation_utils.py
+++ b/src/open_llm_vtuber/conversations/conversation_utils.py
@@ -17,7 +17,8 @@ from ..utils.stream_audio import prepare_audio_payload
 
 # Regex used to detect "substantive" text (same as tts_manager empty check).
 # If after removing these chars the string is empty, we treat as non-substantive.
-_SUBSTANTIVE_STRIP_RE = re.compile(r"[\s.,!?，。！？\'\"』」）】\s]+")
+# Includes ASCII "..." and Unicode ellipsis U+2026.
+_SUBSTANTIVE_STRIP_RE = re.compile(r"[\s.,!?，。！？\'\"』」）】\u2026]+")
 
 
 def is_substantive_response(text: str) -> bool:

--- a/src/open_llm_vtuber/conversations/conversation_utils.py
+++ b/src/open_llm_vtuber/conversations/conversation_utils.py
@@ -117,7 +117,7 @@ async def handle_sentence_output(
         logger.debug(f"🏃 Processing output: '''{tts_text}'''...")
 
         if translate_engine:
-            if len(re.sub(r'[\s.,!?，。！？\'"』」）】\s]+', "", tts_text)):
+            if is_substantive_response(tts_text):
                 tts_text = translate_engine.translate(tts_text)
             logger.info(f"🏃 Text after translation: '''{tts_text}'''...")
         else:

--- a/src/open_llm_vtuber/conversations/single_conversation.py
+++ b/src/open_llm_vtuber/conversations/single_conversation.py
@@ -12,6 +12,7 @@ from .conversation_utils import (
     finalize_conversation_turn,
     cleanup_conversation,
     EMOJI_LIST,
+    is_substantive_response,
 )
 from .types import WebSocketSend
 from .tts_manager import TTSTaskManager
@@ -148,7 +149,11 @@ async def process_single_conversation(
             client_uid=client_uid,
         )
 
-        if context.history_uid and full_response:  # Check full_response before storing
+        if (
+            context.history_uid
+            and full_response
+            and is_substantive_response(full_response)
+        ):
             store_message(
                 conf_uid=context.character_config.conf_uid,
                 history_uid=context.history_uid,
@@ -158,6 +163,11 @@ async def process_single_conversation(
                 avatar=context.character_config.avatar,
             )
             logger.info(f"AI response: {full_response}")
+        elif full_response:
+            logger.debug(
+                "Skipping store and AI response log (non-substantive): %s",
+                full_response,
+            )
 
         return full_response  # Return accumulated full_response
 


### PR DESCRIPTION
## Problem

When I use voice input and speak in short bursts or interrupt often, the AI sometimes only responds with `...` and **no voice is played**—so it feels like no reply at all. This happens especially after several interrupts (For example, saying "Then.", "Alright.", "Hey, I'm here." or longer phrases like "Alright, let's continue."). The log shows `AI response: ...` and the conversation chain completes, but there is no TTS and nothing is stored as a real reply.

## Root cause

1. **Interrupt handling** wrote `heard_response + "..."` into agent memory, so the model kept seeing `...` and `[Interrupted by user]` in context and tended to output only `...` again.
2. **Model output** `"..."` was still added to memory, reinforcing the pattern for the next turn.
3. **Downstream**: `tts_manager` treats `"..."` as empty (punctuation stripped), so it sends a silent payload and never calls TTS—hence no voice.

## Solution

- **handle_interrupt**: Store only `heard_response` (no trailing `"..."`) so we stop polluting context with ellipsis.
- **Simple chat path**: Do not add assistant messages to memory when the model reply is non-substantive (e.g. only `...` or punctuation), breaking the feedback loop.
- **single_conversation**: Do not store or log non-substantive `full_response` as a formal AI reply; use a shared `is_substantive_response()` (aligned with tts_manager’s empty check).
- **System prompt**: Add a short instruction not to reply with only ellipsis or punctuation; use a brief spoken phrase for acknowledgments.

After this fix, when a turn completes (without being interrupted), the AI gives real responses with TTS as expected; the previous "only ... and no voice" issue is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved interruption handling with a clear interrupted signal and brief spoken-style acknowledgments.
  * Added a substantive-response detector to decide whether assistant output is meaningful before saving.

* **Bug Fixes**
  * Prevented storing ellipses, punctuation-only, or empty replies in conversation history.
  * Gate memory additions across tool interactions and final response storage to avoid polluting history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->