### PR TITLE
Add qwen_tts backend support

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -274,7 +274,7 @@ character_config:
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
     #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
     #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts', 'openai_tts', 'qwen_tts'
 
     siliconflow_tts:
       api_url: "https://api.siliconflow.cn/v1/audio/speech"
@@ -417,6 +417,14 @@ character_config:
       api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
       base_url: 'http://localhost:8880/v1' # TTS 服务器的基础 URL 地址
       file_extension: 'mp3' # 音频文件格式（'mp3' 或 'wav'）
+
+    qwen_tts: # 本地 OpenAI 兼容 Qwen TTS 服务的配置示例
+      model: 'qwen3-tts-en-single' # Qwen 服务器预期使用的模型名称
+      voice: 'default' # Qwen 服务器预期使用的声音提示名称
+      api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
+      base_url: 'http://localhost:8000/v1' # Qwen TTS 服务器的基础 URL 地址
+      file_extension: 'wav' # 音频文件格式（'mp3' 或 'wav'）
+      language: 'English' # 可选，转发给 Qwen 服务器的语言参数
     # 详细文档见：https://platform.minimaxi.com/document/Announcement
     minimax_tts:
       group_id: '' # minimax 的 group_id

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -277,7 +277,7 @@ character_config:
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
     #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
     #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts', 'openai_tts', 'qwen_tts'
 
     azure_tts:
       api_key: 'azure-api-key'
@@ -421,6 +421,14 @@ character_config:
       api_key: 'not-needed' # API key if required by the server
       base_url: 'http://localhost:8880/v1' # Base URL of the TTS server
       file_extension: 'mp3' # Audio file format ('mp3' or 'wav')
+
+    qwen_tts: # Configuration for a local OpenAI-compatible Qwen TTS server
+      model: 'qwen3-tts-en-single' # Model name expected by the Qwen server
+      voice: 'default' # Voice prompt name expected by the Qwen server
+      api_key: 'not-needed' # API key if required by the server
+      base_url: 'http://localhost:8000/v1' # Base URL of the Qwen TTS server
+      file_extension: 'wav' # Audio file format ('mp3' or 'wav')
+      language: 'English' # Optional language forwarded to the Qwen server
 
     # For more details, see: https://platform.minimaxi.com/document/Announcement
     minimax_tts:

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -481,6 +481,27 @@ class OpenAITTSConfig(I18nMixin):
     }
 
 
+class QwenTTSConfig(OpenAITTSConfig):
+    """Configuration for Qwen TTS."""
+
+    model: Optional[str] = Field("qwen3-tts-en-single", alias="model")
+    voice: Optional[str] = Field("default", alias="voice")
+    api_key: Optional[str] = Field("not-needed", alias="api_key")
+    base_url: Optional[str] = Field("http://localhost:8000/v1", alias="base_url")
+    file_extension: Literal["mp3", "wav"] = Field("wav", alias="file_extension")
+    language: Optional[str] = Field(None, alias="language")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = dict(OpenAITTSConfig.DESCRIPTIONS)
+    DESCRIPTIONS.update(
+        {
+            "language": Description(
+                en="Optional language forwarded to the qwen TTS server",
+                zh="转发给 Qwen TTS 服务器的可选语言参数",
+            ),
+        }
+    )
+
+
 class SparkTTSConfig(I18nMixin):
     """Configuration for Spark TTS."""
 
@@ -697,6 +718,7 @@ class TTSConfig(I18nMixin):
         "sherpa_onnx_tts",
         "siliconflow_tts",
         "openai_tts",  # Add openai_tts here
+        "qwen_tts",
         "spark_tts",
         "minimax_tts",
         "elevenlabs_tts",
@@ -721,6 +743,7 @@ class TTSConfig(I18nMixin):
         None, alias="siliconflow_tts"
     )
     openai_tts: Optional[OpenAITTSConfig] = Field(None, alias="openai_tts")
+    qwen_tts: Optional[QwenTTSConfig] = Field(None, alias="qwen_tts")
     spark_tts: Optional[SparkTTSConfig] = Field(None, alias="spark_tts")
     minimax_tts: Optional[MinimaxTTSConfig] = Field(None, alias="minimax_tts")
     elevenlabs_tts: ElevenLabsTTSConfig | None = Field(None, alias="elevenlabs_tts")
@@ -758,6 +781,7 @@ class TTSConfig(I18nMixin):
         "openai_tts": Description(
             en="Configuration for OpenAI-compatible TTS", zh="OpenAI 兼容 TTS 配置"
         ),
+        "qwen_tts": Description(en="Configuration for Qwen TTS", zh="Qwen TTS 配置"),
         "spark_tts": Description(en="Configuration for Spark TTS", zh="Spark TTS 配置"),
         "minimax_tts": Description(
             en="Configuration for Minimax TTS", zh="Minimax TTS 配置"
@@ -802,6 +826,8 @@ class TTSConfig(I18nMixin):
             values.siliconflow_tts.model_validate(values.siliconflow_tts.model_dump())
         elif tts_model == "openai_tts" and values.openai_tts is not None:
             values.openai_tts.model_validate(values.openai_tts.model_dump())
+        elif tts_model == "qwen_tts" and values.qwen_tts is not None:
+            values.qwen_tts.model_validate(values.qwen_tts.model_dump())
         elif tts_model == "spark_tts" and values.spark_tts is not None:
             values.spark_tts.model_validate(values.spark_tts.model_dump())
         elif tts_model == "minimax_tts" and values.minimax_tts is not None:

--- a/src/open_llm_vtuber/tts/openai_tts.py
+++ b/src/open_llm_vtuber/tts/openai_tts.py
@@ -1,131 +1,91 @@
 # src/open_llm_vtuber/tts/openai_tts.py
 import os
-import sys
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
-from openai import OpenAI  # Use the official OpenAI library
+from openai import OpenAI
 
 from .tts_interface import TTSInterface
 
-# Add the current directory to sys.path for relative imports if needed
-current_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(current_dir)
-
 
 class TTSEngine(TTSInterface):
-    """
-    Uses an OpenAI-compatible TTS API endpoint to generate speech.
-    Connects to a server specified by `base_url`.
-    API Reference: https://platform.openai.com/docs/api-reference/audio/createSpeech (for standard parameters)
-    """
+    """Use an OpenAI-compatible speech endpoint to generate audio files."""
 
     def __init__(
         self,
-        model="kokoro",  # Default model based on user example
-        voice="af_sky+af_bella",  # Default voice based on user example
-        api_key="not-needed",  # Default for local/compatible servers that don't require auth
-        base_url="http://localhost:8880/v1",  # Default to the specified endpoint
-        file_extension: str = "mp3",  # Configurable file extension
-        **kwargs,  # Allow passing additional args to OpenAI client
-    ):
-        """
-        Initializes the OpenAI TTS engine.
-
-        Args:
-            model (str): The TTS model to use (e.g., 'tts-1', 'tts-1-hd').
-            voice (str): The voice to use (e.g., 'alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer').
-            api_key (str, optional): API key for the TTS service. Defaults to "not-needed".
-            base_url (str, optional): Base URL of the OpenAI-compatible TTS endpoint. Defaults to "http://localhost:8880/v1".
-        """
+        model: str = "kokoro",
+        voice: str = "af_sky+af_bella",
+        api_key: str = "not-needed",
+        base_url: str = "http://localhost:8880/v1",
+        file_extension: str = "mp3",
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the OpenAI-compatible TTS client."""
         self.model = model
         self.voice = voice
-        self.file_extension = file_extension.lower()  # Use configured extension
+        self.base_url = base_url
+        self.file_extension = (file_extension or "mp3").lower()
         if self.file_extension not in ["mp3", "wav"]:
             logger.warning(
                 f"Unsupported file extension '{self.file_extension}' configured for OpenAI TTS. Defaulting to 'mp3'."
             )
             self.file_extension = "mp3"
-        self.new_audio_dir = "cache"
-        self.temp_audio_file = "temp_openai"  # Use a different temp name
 
-        if not os.path.exists(self.new_audio_dir):
-            os.makedirs(self.new_audio_dir)
+        self.new_audio_dir = Path("cache")
+        self.temp_audio_file = "temp_openai"
+        self.new_audio_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            # Initialize OpenAI client
             self.client = OpenAI(api_key=api_key, base_url=base_url, **kwargs)
             logger.info(
                 f"OpenAI-compatible TTS Engine initialized, targeting endpoint: {base_url}"
             )
-        except Exception as e:
-            logger.critical(f"Failed to initialize OpenAI client: {e}")
-            self.client = None  # Ensure client is None if init fails
+        except Exception as exc:
+            logger.critical(f"Failed to initialize OpenAI client: {exc}")
+            self.client = None
+
+    def _build_request_kwargs(self, text: str, speed: float) -> dict[str, Any]:
+        """Build the request payload sent to the OpenAI-compatible endpoint."""
+        return {
+            "model": self.model,
+            "voice": self.voice,
+            "input": text,
+            "response_format": self.file_extension,
+            "speed": speed,
+        }
 
     def generate_audio(self, text, file_name_no_ext=None, speed=1.0):
-        """
-        Generate speech audio file using OpenAI TTS.
-
-        Args:
-            text (str): The text to synthesize.
-            file_name_no_ext (str, optional): Name of the file without extension. Defaults to a generated name.
-            speed (float): The speed of the speech (0.25 to 4.0). Defaults to 1.0.
-
-        Returns:
-            str: The path to the generated audio file, or None if generation failed.
-        """
+        """Generate speech audio using the configured endpoint."""
         if not self.client:
             logger.error("OpenAI client not initialized. Cannot generate audio.")
             return None
 
-        # Use the configured file extension
         file_name = self.generate_cache_file_name(file_name_no_ext, self.file_extension)
         speech_file_path = Path(file_name)
 
         try:
             logger.debug(
-                f"Generating audio via {self.client.base_url} for text: '{text[:50]}...' with voice '{self.voice}' model '{self.model}'"
+                f"Generating audio via {self.base_url} for text: '{text[:50]}...' with voice '{self.voice}' model '{self.model}'"
             )
-            # Use with_streaming_response for potentially better handling of large audio files or network issues
-            with (
-                self.client.audio.speech.with_streaming_response.create(
-                    model=self.model,  # Model name expected by the compatible server (e.g., "kokoro")
-                    voice=self.voice,  # Voice name(s) expected by the compatible server (e.g., "af_sky+af_bella")
-                    input=text,
-                    response_format=self.file_extension,  # Use configured extension
-                    speed=speed,
-                ) as response
-            ):
-                # Stream the audio content to the file
+            with self.client.audio.speech.with_streaming_response.create(
+                **self._build_request_kwargs(text, speed)
+            ) as response:
                 response.stream_to_file(speech_file_path)
 
             logger.info(
                 f"Successfully generated audio file via compatible endpoint: {speech_file_path}"
             )
 
-        except Exception as e:
-            logger.critical(f"Error: OpenAI TTS unable to generate audio: {e}")
-            # Clean up potentially incomplete file
+        except Exception as exc:
+            logger.critical(f"Error: OpenAI TTS unable to generate audio: {exc}")
             if speech_file_path.exists():
                 try:
                     os.remove(speech_file_path)
-                except OSError as rm_err:
+                except OSError as remove_error:
                     logger.error(
-                        f"Could not remove incomplete file {speech_file_path}: {rm_err}"
+                        f"Could not remove incomplete file {speech_file_path}: {remove_error}"
                     )
             return None
 
         return str(speech_file_path)
-
-
-# Example usage (optional, for testing with the compatible endpoint)
-# if __name__ == '__main__':
-#     # Configure TTSEngine to use the specific model and voice from the example
-#     # The base_url and api_key will use the defaults set in __init__
-#     tts_engine = TTSEngine(model="kokoro", voice="af_sky+af_bella")
-#     test_text = "Hello world! This is a test using the compatible endpoint."
-#     audio_path = tts_engine.generate_audio(test_text, "compatible_endpoint_test")
-#     if audio_path:
-#         print(f"Generated audio saved to: {audio_path}")
-#     else:
-#         print("Failed to generate audio.")

--- a/src/open_llm_vtuber/tts/qwen_tts.py
+++ b/src/open_llm_vtuber/tts/qwen_tts.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from .openai_tts import TTSEngine as OpenAITTSEngine
+
+
+class TTSEngine(OpenAITTSEngine):
+    """Use a local Qwen3-compatible speech endpoint through the OpenAI client."""
+
+    def __init__(
+        self,
+        model: str = "qwen3-tts-en-single",
+        voice: str = "default",
+        api_key: str = "not-needed",
+        base_url: str = "http://localhost:8000/v1",
+        file_extension: str = "wav",
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the Qwen TTS engine."""
+        self.language = language
+        super().__init__(
+            model=model,
+            voice=voice,
+            api_key=api_key,
+            base_url=base_url,
+            file_extension=file_extension,
+            **kwargs,
+        )
+
+    def _build_request_kwargs(self, text: str, speed: float) -> dict[str, Any]:
+        """Build a Qwen-compatible request payload."""
+        request_kwargs = super()._build_request_kwargs(text, speed)
+        if self.language:
+            request_kwargs["extra_body"] = {"language": self.language}
+        return request_kwargs

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -154,6 +154,17 @@ class TTSFactory:
                     "file_extension"
                 ),  # Will use default "mp3" if not in kwargs
             )
+        elif engine_type == "qwen_tts":
+            from .qwen_tts import TTSEngine as QwenTTSEngine
+
+            return QwenTTSEngine(
+                model=kwargs.get("model", "qwen3-tts-en-single"),
+                voice=kwargs.get("voice", "default"),
+                api_key=kwargs.get("api_key", "not-needed"),
+                base_url=kwargs.get("base_url", "http://localhost:8000/v1"),
+                file_extension=kwargs.get("file_extension", "wav"),
+                language=kwargs.get("language"),
+            )
 
         elif engine_type == "spark_tts":
             #         api_url: str = "http://127.0.0.1:7860/",

--- a/src/open_llm_vtuber/utils/stream_audio.py
+++ b/src/open_llm_vtuber/utils/stream_audio.py
@@ -1,4 +1,6 @@
+import io
 import base64
+from pathlib import Path
 from pydub import AudioSegment
 from pydub.utils import make_chunks
 from ..agent.output_types import Actions
@@ -60,8 +62,12 @@ def prepare_audio_payload(
         }
 
     try:
-        audio = AudioSegment.from_file(audio_path)
-        audio_bytes = audio.export(format="wav").read()
+        source_format = Path(audio_path).suffix.lstrip(".") or None
+        with open(audio_path, "rb") as audio_file:
+            audio = AudioSegment.from_file(audio_file, format=source_format)
+        audio_buffer = io.BytesIO()
+        audio.export(audio_buffer, format="wav")
+        audio_bytes = audio_buffer.getvalue()
     except Exception as e:
         raise ValueError(
             f"Error loading or converting generated audio file to wav file '{audio_path}': {e}"

--- a/tests/test_qwen_tts.py
+++ b/tests/test_qwen_tts.py
@@ -1,12 +1,38 @@
+import asyncio
+import io
 import json
+import math
+import struct
 import threading
 import unittest
+import wave
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
+from open_llm_vtuber.agent.output_types import Actions, DisplayText
+from open_llm_vtuber.conversations.tts_manager import TTSTaskManager
 from open_llm_vtuber.config_manager.tts import TTSConfig
 from open_llm_vtuber.tts.qwen_tts import TTSEngine as QwenTTSEngine
 from open_llm_vtuber.tts.tts_factory import TTSFactory
+
+
+def _build_test_wav_bytes() -> bytes:
+    sample_rate = 16_000
+    duration_seconds = 0.2
+    total_frames = int(sample_rate * duration_seconds)
+    buffer = io.BytesIO()
+
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        frames = bytearray()
+        for index in range(total_frames):
+            amplitude = int(8_000 * math.sin(2 * math.pi * 440 * index / sample_rate))
+            frames.extend(struct.pack("<h", amplitude))
+        wav_file.writeframes(bytes(frames))
+
+    return buffer.getvalue()
 
 
 class _SpeechHandler(BaseHTTPRequestHandler):
@@ -22,7 +48,7 @@ class _SpeechHandler(BaseHTTPRequestHandler):
             }
         )
 
-        audio = b"RIFF" + b"\x00" * 40
+        audio = _build_test_wav_bytes()
         self.send_response(200)
         self.send_header("Content-Type", "audio/wav")
         self.send_header("Content-Length", str(len(audio)))
@@ -107,6 +133,52 @@ class QwenTTSTest(unittest.TestCase):
                 self.assertEqual(request["body"]["response_format"], "wav")
             finally:
                 engine.remove_file(str(audio_path), verbose=False)
+
+    def test_tts_manager_produces_audio_payload(self) -> None:
+        with _LocalSpeechServer() as local_server:
+            config = _build_config(f"http://127.0.0.1:{local_server.port}/v1")
+            engine = TTSFactory.get_tts_engine(
+                config.tts_model,
+                **config.qwen_tts.model_dump(),
+            )
+
+            async def run_test() -> list[dict]:
+                manager = TTSTaskManager()
+                sent_messages: list[dict] = []
+
+                async def websocket_send(message: str) -> None:
+                    sent_messages.append(json.loads(message))
+
+                await manager.speak(
+                    tts_text="Hello from the TTSTaskManager test.",
+                    display_text=DisplayText(
+                        text="Hello from the TTSTaskManager test.",
+                        name="AI",
+                    ),
+                    actions=Actions(expressions=[1]),
+                    live2d_model=None,
+                    tts_engine=engine,
+                    websocket_send=websocket_send,
+                )
+                await asyncio.gather(*manager.task_list)
+                await asyncio.wait_for(manager._payload_queue.join(), timeout=5)
+                await asyncio.sleep(0.05)
+                manager.clear()
+                return sent_messages
+
+            payloads = asyncio.run(run_test())
+            self.assertEqual(len(payloads), 1)
+
+            payload = payloads[0]
+            self.assertEqual(payload["type"], "audio")
+            self.assertIsNotNone(payload["audio"])
+            self.assertTrue(payload["volumes"])
+            self.assertEqual(payload["display_text"]["name"], "AI")
+            self.assertEqual(
+                payload["display_text"]["text"],
+                "Hello from the TTSTaskManager test.",
+            )
+            self.assertEqual(payload["actions"], {"expressions": [1]})
 
 
 if __name__ == "__main__":

--- a/tests/test_qwen_tts.py
+++ b/tests/test_qwen_tts.py
@@ -1,0 +1,113 @@
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from open_llm_vtuber.config_manager.tts import TTSConfig
+from open_llm_vtuber.tts.qwen_tts import TTSEngine as QwenTTSEngine
+from open_llm_vtuber.tts.tts_factory import TTSFactory
+
+
+class _SpeechHandler(BaseHTTPRequestHandler):
+    requests: list[dict] = []
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.__class__.requests.append(
+            {
+                "path": self.path,
+                "body": json.loads(body.decode("utf-8")),
+            }
+        )
+
+        audio = b"RIFF" + b"\x00" * 40
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(len(audio)))
+        self.end_headers()
+        self.wfile.write(audio)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+class _LocalSpeechServer:
+    def __enter__(self) -> "_LocalSpeechServer":
+        _SpeechHandler.requests.clear()
+        self.server = HTTPServer(("127.0.0.1", 0), _SpeechHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=1)
+
+
+def _build_config(base_url: str) -> TTSConfig:
+    return TTSConfig.model_validate(
+        {
+            "tts_model": "qwen_tts",
+            "qwen_tts": {
+                "model": "qwen3-tts-en-single",
+                "voice": "default",
+                "api_key": "not-needed",
+                "base_url": base_url,
+                "file_extension": "wav",
+                "language": "English",
+            },
+        }
+    )
+
+
+class QwenTTSTest(unittest.TestCase):
+    def test_factory_returns_qwen_tts_engine(self) -> None:
+        config = _build_config("http://127.0.0.1:8000/v1")
+
+        engine = TTSFactory.get_tts_engine(
+            config.tts_model,
+            **config.qwen_tts.model_dump(),
+        )
+
+        self.assertIsInstance(engine, QwenTTSEngine)
+        self.assertEqual(engine.base_url, "http://127.0.0.1:8000/v1")
+        self.assertEqual(engine.voice, "default")
+        self.assertEqual(engine.language, "English")
+
+    def test_qwen_tts_smoke_request(self) -> None:
+        with _LocalSpeechServer() as local_server:
+            config = _build_config(f"http://127.0.0.1:{local_server.port}/v1")
+            engine = TTSFactory.get_tts_engine(
+                config.tts_model,
+                **config.qwen_tts.model_dump(),
+            )
+
+            audio_path = Path(
+                engine.generate_audio(
+                    "Hello from Open-LLM-VTuber",
+                    file_name_no_ext="qwen_tts_smoke",
+                )
+            )
+
+            try:
+                self.assertTrue(audio_path.exists())
+                self.assertEqual(audio_path.suffix, ".wav")
+                self.assertTrue(_SpeechHandler.requests)
+
+                request = _SpeechHandler.requests[-1]
+                self.assertEqual(request["path"], "/v1/audio/speech")
+                self.assertEqual(request["body"]["model"], "qwen3-tts-en-single")
+                self.assertEqual(request["body"]["voice"], "default")
+                self.assertEqual(request["body"]["input"], "Hello from Open-LLM-VTuber")
+                self.assertEqual(request["body"]["language"], "English")
+                self.assertEqual(request["body"]["response_format"], "wav")
+            finally:
+                engine.remove_file(str(audio_path), verbose=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated `qwen_tts` backend for local OpenAI-compatible `/v1/audio/speech` servers
- keep `openai_tts` generic and move Qwen-specific request shaping into `qwen_tts`
- add config wiring and template examples for `qwen_tts`
- add repeatable tests for both the raw adapter request and the `TTSTaskManager` payload path
- close a file-handle warning in `prepare_audio_payload` discovered during integration testing

## Validation
- `python -m compileall src tests/test_qwen_tts.py`
- `uvx ruff check src/open_llm_vtuber/config_manager/tts.py src/open_llm_vtuber/tts/openai_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/tts/qwen_tts.py src/open_llm_vtuber/utils/stream_audio.py tests/test_qwen_tts.py`
- `uvx ruff format --check src/open_llm_vtuber/config_manager/tts.py src/open_llm_vtuber/tts/openai_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/tts/qwen_tts.py src/open_llm_vtuber/utils/stream_audio.py tests/test_qwen_tts.py`
- `uv run --no-project --with pyyaml --with pydantic --with openai --with loguru --with chardet --with pydub python -m unittest discover -s tests -p "test_qwen_tts.py"`
- additional live validation against a real local Qwen3 model server on Windows:
  - direct `POST /v1/audio/speech`
  - `qwen_tts` adapter file generation
  - `TTSTaskManager -> prepare_audio_payload -> websocket_send`

## Notes
- this PR keeps the first integration intentionally small
- Qwen-specific chunk buffering is not included here
- during live validation, upstream Qwen loading on Windows failed on non-ASCII local paths; that issue was handled in the standalone server repo and is outside the Open-LLM-VTuber adapter itself