### PR TITLE
feat: add CAMB AI TTS engine

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -448,6 +448,13 @@ character_config:
       volume: 1.0 # 语音音量（0.5 到 2.0）
       speed: 1.0 # 语音速度（0.6 到 1.5）
 
+    camb_tts:
+      api_key: '' # 从 https://studio.camb.ai 获取 API 密钥
+      voice_id: 147320 # CAMB AI 语音 ID
+      language: 'en-us' # BCP-47 语言代码（如 en-us、es-es、zh-cn、ja-jp）
+      speech_model: 'mars-flash' # MARS 模型：mars-flash（~150ms）、mars-pro、mars-instruct
+      output_format: 'wav' # 输出格式：wav、mp3��flac
+
   # =================== Voice Activity Detection ===================
   vad_config:
     vad_model: null

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -453,6 +453,13 @@ character_config:
       volume: 1.0 # Voice volume (0.5 to 2.0)
       speed: 1.0 # Voice speed (0.6 to 1.5)
 
+    camb_tts:
+      api_key: '' # API key from https://studio.camb.ai
+      voice_id: 147320 # Voice ID from CAMB AI
+      language: 'en-us' # BCP-47 language code (e.g., en-us, es-es, zh-cn, ja-jp)
+      speech_model: 'mars-flash' # MARS model: mars-flash (~150ms), mars-pro, mars-instruct
+      output_format: 'wav' # Output format: wav, mp3, flac
+
   # =================== Voice Activity Detection ===================
   vad_config:
     vad_model: null

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -680,6 +680,38 @@ class CartesiaTTSConfig(I18nMixin):
     }
 
 
+class CambTTSConfig(I18nMixin):
+    """Configuration for CAMB AI TTS."""
+
+    api_key: str = Field(..., alias="api_key")
+    voice_id: int = Field(147320, alias="voice_id")
+    language: str = Field("en-us", alias="language")
+    speech_model: str = Field("mars-flash", alias="speech_model")
+    output_format: str = Field("wav", alias="output_format")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "api_key": Description(
+            en="API key for CAMB AI TTS service", zh="CAMB AI TTS 服务的 API 密钥"
+        ),
+        "voice_id": Description(
+            en="Voice ID from CAMB AI (default: 147320)",
+            zh="来自 CAMB AI 的语音 ID（默认：147320）",
+        ),
+        "language": Description(
+            en="Language code in BCP-47 format (e.g., en-us, es-es, zh-cn)",
+            zh="BCP-47 格式的语言代码（如 en-us、es-es、zh-cn）",
+        ),
+        "speech_model": Description(
+            en="MARS speech model: mars-flash (~150ms), mars-pro (higher quality), mars-instruct (director-level)",
+            zh="MARS 语音模型：mars-flash（~150ms）、mars-pro（更高质量）、mars-instruct（导演级）",
+        ),
+        "output_format": Description(
+            en="Output audio format (wav, mp3, flac)",
+            zh="输出音频格式（wav、mp3、flac）",
+        ),
+    }
+
+
 class TTSConfig(I18nMixin):
     """Configuration for Text-to-Speech."""
 
@@ -702,6 +734,7 @@ class TTSConfig(I18nMixin):
         "elevenlabs_tts",
         "cartesia_tts",
         "piper_tts",
+        "camb_tts",
     ] = Field(..., alias="tts_model")
 
     azure_tts: Optional[AzureTTSConfig] = Field(None, alias="azure_tts")
@@ -726,6 +759,7 @@ class TTSConfig(I18nMixin):
     elevenlabs_tts: ElevenLabsTTSConfig | None = Field(None, alias="elevenlabs_tts")
     cartesia_tts: CartesiaTTSConfig | None = Field(None, alias="cartesia_tts")
     piper_tts: Optional[PiperTTSConfig] = Field(None, alias="piper_tts")
+    camb_tts: Optional[CambTTSConfig] = Field(None, alias="camb_tts")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "tts_model": Description(
@@ -769,6 +803,9 @@ class TTSConfig(I18nMixin):
             en="Configuration for Cartesia TTS", zh="Cartesia TTS 配置"
         ),
         "piper_tts": Description(en="Configuration for Piper TTS", zh="Piper TTS 配置"),
+        "camb_tts": Description(
+            en="Configuration for CAMB AI TTS", zh="CAMB AI TTS 配置"
+        ),
     }
 
     @model_validator(mode="after")
@@ -813,4 +850,6 @@ class TTSConfig(I18nMixin):
 
         elif tts_model == "piper_tts" and values.piper_tts is not None:
             values.piper_tts.model_validate(values.piper_tts.model_dump())
+        elif tts_model == "camb_tts" and values.camb_tts is not None:
+            values.camb_tts.model_validate(values.camb_tts.model_dump())
         return values

--- a/src/open_llm_vtuber/tts/camb_tts.py
+++ b/src/open_llm_vtuber/tts/camb_tts.py
@@ -1,0 +1,92 @@
+# src/open_llm_vtuber/tts/camb_tts.py
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from loguru import logger
+from camb.client import CambAI
+from camb.types import StreamTtsOutputConfiguration
+
+from .tts_interface import TTSInterface
+
+# Load .env from parent camb-ai-work directory as fallback
+_parent_env = Path(__file__).resolve().parents[4] / ".env"
+if _parent_env.exists():
+    load_dotenv(_parent_env, override=False)
+
+
+class TTSEngine(TTSInterface):
+    """
+    Uses CAMB AI TTS API to generate speech.
+    API Reference: https://docs.camb.ai
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        voice_id: int = 147320,
+        language: str = "en-us",
+        speech_model: str = "mars-flash",
+        output_format: str = "wav",
+    ):
+        self.api_key = api_key if api_key else os.getenv("CAMB_API_KEY", "")
+        self.voice_id = voice_id
+        self.language = language
+        self.speech_model = speech_model
+        self.output_format = output_format
+        self.file_extension = output_format if output_format in ("wav", "mp3", "flac") else "wav"
+
+        try:
+            self.client = CambAI(api_key=api_key)
+            logger.info("CAMB AI TTS Engine initialized successfully")
+        except Exception as e:
+            logger.critical(f"Failed to initialize CAMB AI client: {e}")
+            self.client = None
+            raise e
+
+    def generate_audio(
+        self, text: str, file_name_no_ext: str | None = None
+    ) -> str | None:
+        if not self.client:
+            logger.error("CAMB AI client not initialized. Cannot generate audio.")
+            return None
+
+        file_name = self.generate_cache_file_name(file_name_no_ext, self.file_extension)
+        speech_file_path = Path(file_name)
+
+        try:
+            logger.debug(
+                f"Generating audio via CAMB AI for text: '{text[:50]}...' "
+                f"with voice {self.voice_id}, model '{self.speech_model}'"
+            )
+
+            stream = self.client.text_to_speech.tts(
+                text=text,
+                language=self.language,
+                voice_id=self.voice_id,
+                speech_model=self.speech_model,
+                output_configuration=StreamTtsOutputConfiguration(
+                    format=self.output_format
+                ),
+            )
+
+            with open(speech_file_path, "wb") as f:
+                for chunk in stream:
+                    f.write(chunk)
+
+            logger.info(
+                f"Successfully generated audio file via CAMB AI: {speech_file_path}"
+            )
+
+        except Exception as e:
+            logger.critical(f"Error: CAMB AI TTS unable to generate audio: {e}")
+            if speech_file_path.exists():
+                try:
+                    os.remove(speech_file_path)
+                except OSError as rm_err:
+                    logger.error(
+                        f"Could not remove incomplete file {speech_file_path}: {rm_err}"
+                    )
+            raise e
+
+        return str(speech_file_path)

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -211,6 +211,16 @@ class TTSFactory:
                 normalize_audio=kwargs.get("normalize_audio"),
                 use_cuda=kwargs.get("use_cuda"),
             )
+        elif engine_type == "camb_tts":
+            from .camb_tts import TTSEngine as CambTTSEngine
+
+            return CambTTSEngine(
+                api_key=kwargs.get("api_key"),
+                voice_id=kwargs.get("voice_id", 147320),
+                language=kwargs.get("language", "en-us"),
+                speech_model=kwargs.get("speech_model", "mars-flash"),
+                output_format=kwargs.get("output_format", "wav"),
+            )
         else:
             raise ValueError(f"Unknown TTS engine type: {engine_type}")
 


### PR DESCRIPTION
## Summary

- Adds CAMB AI as a new TTS engine option alongside the existing 18+ engines
- Supports streaming TTS via the MARS speech models (mars-flash for ~150ms latency, mars-pro for higher quality)
- Configurable voice ID, language (16 BCP-47 codes), speech model, and output format
- Follows the existing TTSInterface/factory pattern

## About CAMB AI

[CAMB AI](https://camb.ai) is a voice AI and localization platform trusted by brands like the Premier League, the NBA, NASCAR, and the Australian Open. We'd love for CAMB AI to be available as a TTS option in Open-LLM-VTuber.

## Usage

1. `pip install camb-sdk`
2. Set `tts_model: camb_tts` in conf.yaml
3. Configure `api_key`, `voice_id`, `language`, `speech_model` under `camb_tts:`

## Files changed

- `src/open_llm_vtuber/tts/camb_tts.py` - New TTSEngine class
- `src/open_llm_vtuber/tts/tts_factory.py` - Register camb_tts in factory
- `src/open_llm_vtuber/config_manager/tts.py` - Add CambTTSConfig + register in TTSConfig
- `config_templates/conf.default.yaml` - Add default config
- `config_templates/conf.ZH.default.yaml` - Add default config (Chinese)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CAMB AI as a text-to-speech backend option. Configure it with your API key, select a voice, choose your language and speech model, and pick your audio output format (WAV, MP3, or FLAC).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->