### PR TITLE
fix: send plain string content for text-only messages in basic_memory_agent

### DIFF
--- a/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
+++ b/src/open_llm_vtuber/agent/agents/basic_memory_agent.py
@@ -271,7 +271,12 @@ class BasicMemoryAgent(AgentInterface):
                 )
 
         if user_content:
-            user_message = {"role": "user", "content": user_content}
+            # Use plain string when text-only for broader API compatibility
+            if len(user_content) == 1 and user_content[0]["type"] == "text":
+                content = user_content[0]["text"]
+            else:
+                content = user_content
+            user_message = {"role": "user", "content": content}
             messages.append(user_message)
 
             skip_memory = False


### PR DESCRIPTION
## Summary

- User message content was always wrapped in multimodal array format (`[{"type": "text", "text": "..."}]`) even when no images were present
- Many LLM APIs (OpenRouter free models, and others) reject this format with a 404 `No endpoints found that support image input` error
- Now uses a plain string for text-only messages, falling back to array format only when images are actually included

## Test plan

- [x] Verify text-only conversations work with APIs that don't support multimodal input (e.g. OpenRouter free tier models)
- [x] Verify image input still works correctly when images are attached (array format preserved)
- [x] Verify existing vision-capable providers (OpenAI, Claude) still work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message formatting for better OpenAI API compatibility. Text-only chat interactions are now serialized as plain strings, reducing payload size and streamlining API requests. Mixed-media inputs containing images or multiple content blocks continue using their structured format. These changes enhance communication efficiency and overall reliability with the language model backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->