### PR TITLE
fix: resolve httpx 0.28+ connection error with local LLM backends

### DIFF
--- a/src/open_llm_vtuber/agent/stateless_llm/openai_compatible_llm.py
+++ b/src/open_llm_vtuber/agent/stateless_llm/openai_compatible_llm.py
@@ -4,6 +4,7 @@ endpoints for language generation.
 """
 
 from typing import AsyncIterator, List, Dict, Any
+import httpx
 from openai import (
     AsyncStream,
     AsyncOpenAI,
@@ -50,6 +51,9 @@ class AsyncLLM(StatelessLLMInterface):
             organization=organization_id,
             project=project_id,
             api_key=llm_api_key,
+            http_client=httpx.AsyncClient(
+                transport=httpx.AsyncHTTPTransport(retries=1),
+            ),
         )
         self.support_tools = True
 


### PR DESCRIPTION
httpx 0.28 introduced stricter connection handling that causes `RemoteProtocolError: Server disconnected without sending a response` on the first request to servers like Ollama. Configure the AsyncOpenAI client with `AsyncHTTPTransport(retries=1)` so httpx automatically retries on a fresh connection when the initial one is dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced HTTP client reliability with explicit retry handling for API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->