### PR TITLE
feat: allow disabling TTS via 'none' option in tts_model

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -271,10 +271,12 @@ character_config:
   tts_config:
     tts_model: 'edge_tts' # 使用的文本转语音模型
     # 文本转语音模型选项：
-    #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
-    #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
-    #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'none', 'azure_tts', 'bark_tts', 'edge_tts', 'cosyvoice_tts',
+    #   'cosyvoice2_tts', 'melo_tts', 'coqui_tts', 'x_tts',
+    #   'gpt_sovits_tts', 'fish_api_tts', 'sherpa_onnx_tts',
+    #   'siliconflow_tts', 'openai_tts', 'spark_tts', 'minimax_tts',
+    #   'elevenlabs_tts', 'cartesia_tts', 'piper_tts'
+    # 设置为 'none' 可禁用 TTS（聊天中仍会显示文本）。
 
     siliconflow_tts:
       api_url: "https://api.siliconflow.cn/v1/audio/speech"

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -274,10 +274,12 @@ character_config:
   tts_config:
     tts_model: 'edge_tts'
     # text to speech model options:
-    #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
-    #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
-    #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'none', 'azure_tts', 'bark_tts', 'edge_tts', 'cosyvoice_tts',
+    #   'cosyvoice2_tts', 'melo_tts', 'coqui_tts', 'x_tts',
+    #   'gpt_sovits_tts', 'fish_api_tts', 'sherpa_onnx_tts',
+    #   'siliconflow_tts', 'openai_tts', 'spark_tts', 'minimax_tts',
+    #   'elevenlabs_tts', 'cartesia_tts', 'piper_tts'
+    # Set to 'none' to disable TTS (text will still be displayed in the chat).
 
     azure_tts:
       api_key: 'azure-api-key'

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -683,26 +683,30 @@ class CartesiaTTSConfig(I18nMixin):
 class TTSConfig(I18nMixin):
     """Configuration for Text-to-Speech."""
 
-    tts_model: Literal[
-        "azure_tts",
-        "bark_tts",
-        "edge_tts",
-        "cosyvoice_tts",
-        "cosyvoice2_tts",
-        "melo_tts",
-        "coqui_tts",
-        "x_tts",
-        "gpt_sovits_tts",
-        "fish_api_tts",
-        "sherpa_onnx_tts",
-        "siliconflow_tts",
-        "openai_tts",  # Add openai_tts here
-        "spark_tts",
-        "minimax_tts",
-        "elevenlabs_tts",
-        "cartesia_tts",
-        "piper_tts",
-    ] = Field(..., alias="tts_model")
+    tts_model: (
+        Literal[
+            "azure_tts",
+            "bark_tts",
+            "edge_tts",
+            "cosyvoice_tts",
+            "cosyvoice2_tts",
+            "melo_tts",
+            "coqui_tts",
+            "x_tts",
+            "gpt_sovits_tts",
+            "fish_api_tts",
+            "sherpa_onnx_tts",
+            "siliconflow_tts",
+            "openai_tts",
+            "spark_tts",
+            "minimax_tts",
+            "elevenlabs_tts",
+            "cartesia_tts",
+            "piper_tts",
+            "none",
+        ]
+        | None
+    ) = Field("edge_tts", alias="tts_model")
 
     azure_tts: Optional[AzureTTSConfig] = Field(None, alias="azure_tts")
     bark_tts: Optional[BarkTTSConfig] = Field(None, alias="bark_tts")

--- a/src/open_llm_vtuber/conversations/tts_manager.py
+++ b/src/open_llm_vtuber/conversations/tts_manager.py
@@ -33,7 +33,7 @@ class TTSTaskManager:
         display_text: DisplayText,
         actions: Optional[Actions],
         live2d_model: Live2dModel,
-        tts_engine: TTSInterface,
+        tts_engine: TTSInterface | None,
         websocket_send: WebSocketSend,
     ) -> None:
         """
@@ -54,6 +54,18 @@ class TTSTaskManager:
             self._sequence_counter += 1
 
             # Start sender task if not running
+            if not self._sender_task or self._sender_task.done():
+                self._sender_task = asyncio.create_task(
+                    self._process_payload_queue(websocket_send)
+                )
+
+            await self._send_silent_payload(display_text, actions, current_sequence)
+            return
+
+        if tts_engine is None:
+            current_sequence = self._sequence_counter
+            self._sequence_counter += 1
+
             if not self._sender_task or self._sender_task.done():
                 self._sender_task = asyncio.create_task(
                     self._process_payload_queue(websocket_send)

--- a/src/open_llm_vtuber/routes.py
+++ b/src/open_llm_vtuber/routes.py
@@ -213,6 +213,11 @@ def init_webtool_routes(default_context_cache: ServiceContext) -> APIRouter:
 
                 logger.info(f"Received text for TTS: {text}")
 
+                if default_context_cache.tts_engine is None:
+                    logger.info("TTS is disabled, skipping audio generation")
+                    await websocket.send_json({"status": "complete"})
+                    continue
+
                 # Split text into sentences
                 sentences = [s.strip() for s in text.split(".") if s.strip()]
 

--- a/src/open_llm_vtuber/service_context.py
+++ b/src/open_llm_vtuber/service_context.py
@@ -49,7 +49,7 @@ class ServiceContext:
 
         self.live2d_model: Live2dModel = None
         self.asr_engine: ASRInterface = None
-        self.tts_engine: TTSInterface = None
+        self.tts_engine: TTSInterface | None = None
         self.agent_engine: AgentInterface = None
         # translate_engine can be none if translation is disabled
         self.vad_engine: VADInterface | None = None
@@ -333,6 +333,12 @@ class ServiceContext:
             logger.info("ASR already initialized with the same config.")
 
     def init_tts(self, tts_config: TTSConfig) -> None:
+        if tts_config.tts_model in (None, "none"):
+            logger.info("TTS is disabled.")
+            self.tts_engine = None
+            self.character_config.tts_config = tts_config
+            return
+
         if not self.tts_engine or (self.character_config.tts_config != tts_config):
             logger.info(f"Initializing TTS: {tts_config.tts_model}")
             self.tts_engine = TTSFactory.get_tts_engine(

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -1,10 +1,11 @@
-from typing import Type
 from .tts_interface import TTSInterface
 
 
 class TTSFactory:
     @staticmethod
-    def get_tts_engine(engine_type, **kwargs) -> Type[TTSInterface]:
+    def get_tts_engine(engine_type, **kwargs) -> TTSInterface | None:
+        if engine_type in (None, "none"):
+            return None
         if engine_type == "azure_tts":
             from .azure_tts import TTSEngine as AzureTTSEngine
 


### PR DESCRIPTION
## 改动说明
- 新增 tts_model 的 'none' 选项，用于完全禁用 TTS 功能。
- 当设为 'none' 时：
  - tts_factory 返回 None，不再抛出异常
  - service_context 处理缺失的 TTS 引擎
  - tts_manager 跳过音频生成
  - routes 接口在 TTS 禁用时返回空列表
- 文本回复在聊天 UI 中仍正常显示。
- 同时更新了中英文配置模板。

## 必要性
- 有时候只是调prompt没必要开重型tts，而edge地区封锁报错看着很讨厌。
- 提供显式禁用选项，避免讨厌的错误日志和critical。
（这是我第一次提交pr如果有什么做的不对的地方请告诉我，本地跑起来没有问题）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TTS can be fully disabled by choosing "none" as the TTS model.
  * When TTS is disabled, chat text is still shown and the server immediately marks playback as complete (no audio generation).

* **Documentation**
  * Configuration templates updated to document the "none" option and additional TTS provider identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->