### PR TITLE
Backend groundwork for muting over websocket

### DIFF
--- a/src/open_llm_vtuber/websocket_handler.py
+++ b/src/open_llm_vtuber/websocket_handler.py
@@ -488,7 +488,7 @@ class WebSocketHandler:
     ) -> None:
         """Handle incoming audio data"""
         if self.client_input_muted.get(client_uid, False):
-            "Client input is muted, ignoring audio data"
+            logger.debug(f"Ignoring audio data received from muted client {client_uid}")
             return
         audio_data = data.get("audio", [])
         if audio_data:
@@ -503,7 +503,7 @@ class WebSocketHandler:
         """Handle incoming raw audio data for VAD processing"""
         context = self.client_contexts[client_uid]
         if self.client_input_muted.get(client_uid, False):
-            "Client input is muted, ignoring raw audio data"
+            logger.debug(f"Ignoring raw audio data received from muted client {client_uid}")
             return
         chunk = data.get("audio", [])
         if chunk:
@@ -629,18 +629,28 @@ class WebSocketHandler:
         self, websocket: WebSocket, client_uid: str, data: WSMessage
     ) -> None:
         """Handle setting input mute status for a client"""
-        muted = bool(data.get("muted", False))
+        muted_value = data.get("muted")
+
+        if type(muted_value) is not bool:
+            logger.warning(f"Invalid muted value received: {muted_value}")
+            await websocket.send_json(
+                {
+                    "type": "error", 
+                    "message": "Invalid value for muted. Expected boolean.",
+                }
+            )
+            return
+        
+        muted = muted_value
         self.client_input_muted[client_uid] = muted
 
         if muted:
             # If muting input, also clear any buffered audio data
             self.received_data_buffers[client_uid] = np.array([])
         
-        await websocket.send_text(
-            json.dumps(
-                {
-                    "type": "input-mute-state",
-                    "muted": muted,
-                }
-            )
+        await websocket.send_json(
+            {
+                "type": "input-mute-state",
+                "muted": muted,
+            }
         )

--- a/src/open_llm_vtuber/websocket_handler.py
+++ b/src/open_llm_vtuber/websocket_handler.py
@@ -56,6 +56,7 @@ class WSMessage(TypedDict, total=False):
     history_uid: Optional[str]
     file: Optional[str]
     display_text: Optional[dict]
+    muted: Optional[bool]
 
 
 class WebSocketHandler:
@@ -69,6 +70,7 @@ class WebSocketHandler:
         self.current_conversation_tasks: Dict[str, Optional[asyncio.Task]] = {}
         self.default_context_cache = default_context_cache
         self.received_data_buffers: Dict[str, np.ndarray] = {}
+        self.client_input_muted: Dict[str, bool] = {}
 
         # Message handlers mapping
         self._message_handlers = self._init_message_handlers()
@@ -95,6 +97,7 @@ class WebSocketHandler:
             "audio-play-start": self._handle_audio_play_start,
             "request-init-config": self._handle_init_config_request,
             "heartbeat": self._handle_heartbeat,
+            "set-input-mute": self._handle_set_input_mute,
         }
 
     async def handle_new_connection(
@@ -123,6 +126,8 @@ class WebSocketHandler:
                 websocket, client_uid, session_service_context
             )
 
+            self.client_input_muted[client_uid] = False
+
             logger.info(f"Connection established for client {client_uid}")
 
         except Exception as e:
@@ -142,6 +147,7 @@ class WebSocketHandler:
         self.client_connections[client_uid] = websocket
         self.client_contexts[client_uid] = session_service_context
         self.received_data_buffers[client_uid] = np.array([])
+        self.client_input_muted[client_uid] = False
 
         self.chat_group_manager.client_group_map[client_uid] = ""
         await self.send_group_update(websocket, client_uid)
@@ -301,6 +307,7 @@ class WebSocketHandler:
         self.client_connections.pop(client_uid, None)
         self.client_contexts.pop(client_uid, None)
         self.received_data_buffers.pop(client_uid, None)
+        self.client_input_muted.pop(client_uid, None)
         if client_uid in self.current_conversation_tasks:
             task = self.current_conversation_tasks[client_uid]
             if task and not task.done():
@@ -321,6 +328,7 @@ class WebSocketHandler:
         self.client_contexts.pop(client_uid, None)
         self.received_data_buffers.pop(client_uid, None)
         self.chat_group_manager.client_group_map.pop(client_uid, None)
+        self.client_input_muted.pop(client_uid, None)
 
         if client_uid in self.current_conversation_tasks:
             task = self.current_conversation_tasks[client_uid]
@@ -479,6 +487,9 @@ class WebSocketHandler:
         self, websocket: WebSocket, client_uid: str, data: WSMessage
     ) -> None:
         """Handle incoming audio data"""
+        if self.client_input_muted.get(client_uid, False):
+            "Client input is muted, ignoring audio data"
+            return
         audio_data = data.get("audio", [])
         if audio_data:
             self.received_data_buffers[client_uid] = np.append(
@@ -491,6 +502,9 @@ class WebSocketHandler:
     ) -> None:
         """Handle incoming raw audio data for VAD processing"""
         context = self.client_contexts[client_uid]
+        if self.client_input_muted.get(client_uid, False):
+            "Client input is muted, ignoring raw audio data"
+            return
         chunk = data.get("audio", [])
         if chunk:
             for audio_bytes in context.vad_engine.detect_speech(chunk):
@@ -610,3 +624,23 @@ class WebSocketHandler:
             await websocket.send_json({"type": "heartbeat-ack"})
         except Exception as e:
             logger.error(f"Error sending heartbeat acknowledgment: {e}")
+
+    async def _handle_set_input_mute(
+        self, websocket: WebSocket, client_uid: str, data: WSMessage
+    ) -> None:
+        """Handle setting input mute status for a client"""
+        muted = bool(data.get("muted", False))
+        self.client_input_muted[client_uid] = muted
+
+        if muted:
+            # If muting input, also clear any buffered audio data
+            self.received_data_buffers[client_uid] = np.array([])
+        
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "type": "input-mute-state",
+                    "muted": muted,
+                }
+            )
+        )


### PR DESCRIPTION
# Summary

- Adds a per-client backend mute state for microphone input
- Prevents voice audio from being buffered/processed while muted
- Leaves text chat and other controls unaffected
- Establishes groundwork for future frontend and hotkey integrations

I should be clear that this is *just* the backend groundwork for a feature that allows global muting of audio, addressing a particular issue raised in Issues. I did not want to touch too much, so either a front end, or global hot-key configuration will still need to be implemented to complete this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input-mute control allowing clients to mute/unmute microphone input.
  * Mute state tracked per client and acknowledged with state responses.
  * Buffered audio cleared when input is muted.
  * Muted clients’ microphone input is ignored by the system.
  * Invalid mute requests return an error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->