### PR TITLE
fix: correct end-punctuation regex in sentence segmenter

### DIFF
--- a/src/open_llm_vtuber/utils/sentence_divider.py
+++ b/src/open_llm_vtuber/utils/sentence_divider.py
@@ -187,9 +187,14 @@ def segment_text_by_regex(text: str) -> Tuple[List[str], str]:
     complete_sentences = []
     remaining_text = text.strip()
 
-    # Create pattern for matching sentences ending with any end punctuation
-    escaped_punctuations = [re.escape(p) for p in END_PUNCTUATIONS]
-    pattern = r"(.*?(?:[" + "|".join(escaped_punctuations) + r"]))"
+    # Create pattern for matching sentences ending with any end punctuation.
+    # Use a real alternation (?:a|b|...) rather than a character class [a|b|...]:
+    # inside a character class "|" is a literal pipe and multi-character
+    # punctuation like "..." collapses to a single ".". Longer punctuation is
+    # listed first so e.g. "..." matches before "." and is not split apart.
+    ordered_punctuations = sorted(END_PUNCTUATIONS, key=len, reverse=True)
+    escaped_punctuations = [re.escape(p) for p in ordered_punctuations]
+    pattern = r"(.*?(?:" + "|".join(escaped_punctuations) + r"))"
 
     while remaining_text:
         match = re.search(pattern, remaining_text)

--- a/tests/test_sentence_divider.py
+++ b/tests/test_sentence_divider.py
@@ -1,0 +1,55 @@
+"""Regression tests for the regex sentence segmenter.
+
+These cover a bug where ``segment_text_by_regex`` built its end-punctuation
+matcher as a character class (``[...]``) joined with ``|`` instead of a real
+alternation. Inside a character class ``|`` is a literal pipe and multi-character
+punctuation such as ``"..."`` collapses to a single ``.``. As a result:
+
+* a literal ``|`` in normal text was treated as sentence-ending punctuation and
+  split a sentence mid-phrase, and
+* an ellipsis ``"..."`` was shattered into three separate ``"."`` fragments.
+
+Each fragment is sent to TTS and shown as its own subtitle, so this corrupted
+both spoken audio and on-screen text. The segmenter is reached when
+``segment_method`` is ``"regex"`` and also as the automatic fallback from the
+pysbd path for unsupported languages or on any pysbd error.
+"""
+
+from open_llm_vtuber.utils.sentence_divider import segment_text_by_regex
+
+
+def test_pipe_is_not_treated_as_sentence_end():
+    """A literal '|' must not split a sentence."""
+    text = "You can use grep | wc to count lines and then move on."
+    sentences, remaining = segment_text_by_regex(text)
+    assert sentences == [text]
+    assert remaining == ""
+
+
+def test_multiple_pipes_do_not_split():
+    text = "The options are red | green | blue and you should pick one."
+    sentences, remaining = segment_text_by_regex(text)
+    assert sentences == [text]
+    assert remaining == ""
+
+
+def test_ellipsis_is_not_shattered():
+    """'...' must stay attached to its sentence, not become three '.' fragments."""
+    sentences, remaining = segment_text_by_regex("Wait... what happened?")
+    assert sentences == ["Wait...", "what happened?"]
+    assert remaining == ""
+    # No empty / punctuation-only fragments should leak through.
+    assert all(s.strip(".") for s in sentences)
+
+
+def test_normal_sentences_still_segment():
+    """Ordinary punctuation behaviour is unchanged."""
+    sentences, remaining = segment_text_by_regex("Hello world. How are you?")
+    assert sentences == ["Hello world.", "How are you?"]
+    assert remaining == ""
+
+
+def test_cjk_full_stop_still_segments():
+    sentences, remaining = segment_text_by_regex("这是第一句。这是第二句。")
+    assert sentences == ["这是第一句。", "这是第二句。"]
+    assert remaining == ""


### PR DESCRIPTION
## Bug

`segment_text_by_regex` in `src/open_llm_vtuber/utils/sentence_divider.py` builds its end-punctuation matcher as a **character class** joined with `|` instead of a real alternation:

```python
escaped_punctuations = [re.escape(p) for p in END_PUNCTUATIONS]
pattern = r"(.*?(?:[" + "|".join(escaped_punctuations) + r"]))"
```

Inside a character class `[...]`, `|` is a **literal pipe**, and multi-character punctuation like `"..."` / `"。。。"` collapses to a single `.` / `。`. So the pattern unintentionally treats `|` as sentence-ending punctuation and cannot match a real ellipsis as one unit.

### Impact

`segment_text_by_regex` is reachable both directly (`segment_method: "regex"`, a supported config value) **and** as the automatic fallback from the pysbd path — for languages pysbd does not support, or whenever pysbd raises (`segment_text_by_pysbd` falls back to it on any exception). So this affects default (`pysbd`) setups too.

Because each returned fragment is sent to TTS and rendered as its own subtitle, the mis-segmentation corrupts **both the spoken audio and the on-screen text**.

### Reproduction

```python
from open_llm_vtuber.utils.sentence_divider import segment_text_by_regex

segment_text_by_regex("You can use grep | wc to count lines and then move on.")[0]
# -> ['You can use grep |', 'wc to count lines and then move on.']
#    a literal "|" splits the sentence mid-phrase

segment_text_by_regex("Wait... what happened?")[0]
# -> ['Wait.', '.', '.', 'what happened?']
#    "..." is shattered into three punctuation-only fragments
```

## Root cause

The punctuation list was placed inside a `[...]` character class, where `|` is literal and multi-char sequences lose their meaning. The intent was an alternation over the whole punctuation strings.

## Fix

Build a proper non-capturing alternation `(?:...|...)`, and list longer punctuation first so `"..."` matches before `"."` and is not split apart:

```python
ordered_punctuations = sorted(END_PUNCTUATIONS, key=len, reverse=True)
escaped_punctuations = [re.escape(p) for p in ordered_punctuations]
pattern = r"(.*?(?:" + "|".join(escaped_punctuations) + r"))"
```

One logic line changed; no other behaviour touched.

After the fix:

```python
segment_text_by_regex("You can use grep | wc to count lines and then move on.")[0]
# -> ['You can use grep | wc to count lines and then move on.']

segment_text_by_regex("Wait... what happened?")[0]
# -> ['Wait...', 'what happened?']
```

## Tests

Adds `tests/test_sentence_divider.py` (first tests in the repo). The pipe and ellipsis cases **fail before** this change and **pass after**; normal English and CJK segmentation tests pass both before and after, confirming no regression.

```
# before fix
3 failed, 2 passed
# after fix
5 passed
```

Run with:

```bash
PYTHONPATH=src pytest tests/test_sentence_divider.py -v
```

`ruff check` and `ruff format --check` pass on both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sentence segmentation to properly handle multi-character punctuation marks, including ellipsis and special characters.

* **Tests**
  * Added comprehensive test coverage for sentence segmentation, verifying correct handling across various punctuation types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->