### PR TITLE
fix: ignore braces inside streamed JSON strings

### DIFF
--- a/src/open_llm_vtuber/mcpp/json_detector.py
+++ b/src/open_llm_vtuber/mcpp/json_detector.py
@@ -99,11 +99,20 @@ class StreamJSONDetector:
         """
         stack = 1
         i = start_idx + 1
+        in_string = False
+        escaped = False
 
         while i < len(self.buffer) and stack > 0:
-            if self.buffer[i] == "{":
+            char = self.buffer[i]
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = not in_string
+            elif not in_string and char == "{":
                 stack += 1
-            elif self.buffer[i] == "}":
+            elif not in_string and char == "}":
                 stack -= 1
             i += 1
 

--- a/tests/test_json_detector.py
+++ b/tests/test_json_detector.py
@@ -1,0 +1,17 @@
+from open_llm_vtuber.mcpp.json_detector import StreamJSONDetector
+
+
+def test_process_chunk_ignores_braces_inside_strings():
+    detector = StreamJSONDetector()
+
+    result = detector.process_chunk('prefix {"text": "literal } brace", "ok": true} suffix')
+
+    assert result == [{"text": "literal } brace", "ok": True}]
+
+
+def test_process_chunk_handles_escaped_quotes_before_braces():
+    detector = StreamJSONDetector()
+
+    result = detector.process_chunk('{"text": "quoted \\"}\\"", "ok": true}')
+
+    assert result == [{"text": 'quoted "}"', "ok": True}]


### PR DESCRIPTION
## Summary\n- make StreamJSONDetector ignore braces while inside JSON strings\n- handle escaped quotes before brace characters\n- add regression tests for streamed JSON strings containing braces\n\n## Testing\n- PYTHONPATH=src uv run --with pytest python -m pytest tests/test_json_detector.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON detection now correctly handles braces within string literals and escaped quotes, preventing incorrect object termination.

* **Tests**
  * Added unit tests verifying proper handling of edge cases in JSON parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->