### PR TITLE
feat(tts): Add F5-TTS support

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -314,6 +314,21 @@ character_config:
       normalize_audio: true     # 是否归一化音频（推荐启用，使音量更稳定）
       use_cuda: false           # 是否使用 GPU 加速（需要安装 onnxruntime-gpu）
 
+    f5_tts:
+      # F5-TTS: 基于流匹配的语音克隆 TTS
+      # 安装: pip install f5-tts
+      # 参考: https://github.com/SWivid/F5-TTS
+      ref_audio: 'path/to/reference.wav'   # 用于声音克隆的参考音频文件路径
+      ref_text: ''                          # 参考音频的文字内容（留空则自动转录）
+      model: 'F5TTS_v1_Base'               # 模型: F5TTS_v1_Base, F5TTS_Base, E2TTS_Base
+      device: ''                            # 设备: cuda, cpu, mps, xpu（留空自动检测）
+      remove_silence: false                 # 是否移除生成音频中的静音部分
+      speed: 1.0                            # 语速倍数
+      cross_fade_duration: 0.15             # 音频块之间的交叉淡入淡出时长（秒）
+      nfe_step: 32                          # 函数评估次数（越高质量越好）
+      cfg_strength: 2.0                     # 无分类器引导强度
+      sway_sampling_coef: -1.0              # Sway采样系数（-1 禁用）
+
     cosyvoice_tts: # Cosy Voice TTS 连接到 gradio webui
       # 查看他们的文档以了解部署和以下配置的含义
       client_url: 'http://127.0.0.1:50000/' # CosyVoice gradio 演示 webui url

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -272,9 +272,11 @@ character_config:
     tts_model: 'edge_tts' # 使用的文本转语音模型
     # 文本转语音模型选项：
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
-    #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
-    #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'cosyvoice_tts', 'cosyvoice2_tts', 'melo_tts', 'coqui_tts',
+    #   'piper_tts', 'fish_api_tts', 'x_tts', 'gpt_sovits_tts',
+    #   'sherpa_onnx_tts', 'minimax_tts', 'elevenlabs_tts',
+    #   'cartesia_tts', 'openai_tts', 'spark_tts', 'siliconflow_tts',
+    #   'f5_tts'
 
     siliconflow_tts:
       api_url: "https://api.siliconflow.cn/v1/audio/speech"

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -278,6 +278,7 @@ character_config:
     #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
     #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
     #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'f5_tts'
 
     azure_tts:
       api_key: 'azure-api-key'
@@ -305,6 +306,21 @@ character_config:
       volume: 1.0               # Volume level (0.0–1.0; 1.0 = normal)
       normalize_audio: true     # Whether to normalize audio (recommended: true, for more consistent volume)
       use_cuda: false           # Whether to use GPU acceleration (requires onnxruntime-gpu)
+
+    f5_tts:
+      # F5-TTS: Flow matching based TTS with voice cloning
+      # Requires: pip install f5-tts
+      # See: https://github.com/SWivid/F5-TTS
+      ref_audio: 'path/to/reference.wav'   # Path to reference audio file for voice cloning
+      ref_text: ''                          # Transcription of reference audio (empty = auto-transcribe)
+      model: 'F5TTS_v1_Base'               # Model: F5TTS_v1_Base, F5TTS_Base, E2TTS_Base
+      device: ''                            # Device: cuda, cpu, mps, xpu (empty = auto-detect)
+      remove_silence: false                 # Remove silence from generated audio
+      speed: 1.0                            # Speech speed multiplier
+      cross_fade_duration: 0.15             # Cross-fade duration between chunks (seconds)
+      nfe_step: 32                          # Number of function evaluations (higher = better quality)
+      cfg_strength: 2.0                     # Classifier-free guidance strength
+      sway_sampling_coef: -1.0              # Sway sampling coefficient (-1 to disable)
 
     cosyvoice_tts: # Cosy Voice TTS connects to the gradio webui
       # Check their documentation for deployment and the meaning of the following configurations

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -275,9 +275,10 @@ character_config:
     tts_model: 'edge_tts'
     # text to speech model options:
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
-    #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
-    #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'cosyvoice_tts', 'cosyvoice2_tts', 'melo_tts', 'coqui_tts',
+    #   'piper_tts', 'fish_api_tts', 'x_tts', 'gpt_sovits_tts',
+    #   'sherpa_onnx_tts', 'minimax_tts', 'elevenlabs_tts',
+    #   'cartesia_tts', 'openai_tts', 'spark_tts', 'siliconflow_tts',
     #   'f5_tts'
 
     azure_tts:

--- a/src/open_llm_vtuber/config_manager/__init__.py
+++ b/src/open_llm_vtuber/config_manager/__init__.py
@@ -37,6 +37,7 @@ from .tts import (
     GPTSoVITSConfig,
     FishAPITTSConfig,
     SherpaOnnxTTSConfig,
+    F5TTSConfig,
 )
 from .vad import (
     VADConfig,
@@ -105,6 +106,7 @@ __all__ = [
     "GPTSoVITSConfig",
     "FishAPITTSConfig",
     "SherpaOnnxTTSConfig",
+    "F5TTSConfig",
     # VAD related classes
     "VADConfig",
     "SileroVADConfig",

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -834,6 +834,7 @@ class TTSConfig(I18nMixin):
 
     @model_validator(mode="after")
     def check_tts_config(cls, values: "TTSConfig", info: ValidationInfo):
+        """Validate the TTS configuration for the selected model."""
         tts_model = values.tts_model
 
         # Only validate the selected TTS model

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -680,6 +680,65 @@ class CartesiaTTSConfig(I18nMixin):
     }
 
 
+
+
+class F5TTSConfig(I18nMixin):
+    """Configuration for F5-TTS."""
+
+    ref_audio: str = Field(..., alias="ref_audio")
+    ref_text: str = Field("", alias="ref_text")
+    model: str = Field("F5TTS_v1_Base", alias="model")
+    device: str = Field("", alias="device")
+    remove_silence: bool = Field(False, alias="remove_silence")
+    speed: float = Field(1.0, alias="speed")
+    cross_fade_duration: float = Field(0.15, alias="cross_fade_duration")
+    nfe_step: int = Field(32, alias="nfe_step")
+    cfg_strength: float = Field(2.0, alias="cfg_strength")
+    sway_sampling_coef: float = Field(-1.0, alias="sway_sampling_coef")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "ref_audio": Description(
+            en="Path to reference audio file for voice cloning",
+            zh="用于声音克隆的参考音频文件路径",
+        ),
+        "ref_text": Description(
+            en="Transcription of the reference audio (leave empty for auto-transcription)",
+            zh="参考音频的文字内容（留空则自动转录）",
+        ),
+        "model": Description(
+            en="Model name (F5TTS_v1_Base, F5TTS_Base, E2TTS_Base)",
+            zh="模型名称（F5TTS_v1_Base、F5TTS_Base、E2TTS_Base）",
+        ),
+        "device": Description(
+            en="Device to use (cuda, cpu, mps, xpu). Empty for auto-detect",
+            zh="使用的设备（cuda、cpu、mps、xpu）。留空自动检测",
+        ),
+        "remove_silence": Description(
+            en="Whether to remove silence from generated audio",
+            zh="是否移除生成音频中的静音部分",
+        ),
+        "speed": Description(
+            en="Speech speed multiplier (1.0 = normal)",
+            zh="语速倍数（1.0 = 正常）",
+        ),
+        "cross_fade_duration": Description(
+            en="Cross-fade duration in seconds between audio chunks",
+            zh="音频块之间的交叉淡入淡出时长（秒）",
+        ),
+        "nfe_step": Description(
+            en="Number of function evaluations (higher = better quality, slower)",
+            zh="函数评估次数（越高质量越好，速度越慢）",
+        ),
+        "cfg_strength": Description(
+            en="Classifier-free guidance strength",
+            zh="无分类器引导强度",
+        ),
+        "sway_sampling_coef": Description(
+            en="Sway sampling coefficient (-1 to disable)",
+            zh="Sway采样系数（-1 禁用）",
+        ),
+    }
+
 class TTSConfig(I18nMixin):
     """Configuration for Text-to-Speech."""
 
@@ -702,6 +761,7 @@ class TTSConfig(I18nMixin):
         "elevenlabs_tts",
         "cartesia_tts",
         "piper_tts",
+        "f5_tts",
     ] = Field(..., alias="tts_model")
 
     azure_tts: Optional[AzureTTSConfig] = Field(None, alias="azure_tts")
@@ -726,6 +786,7 @@ class TTSConfig(I18nMixin):
     elevenlabs_tts: ElevenLabsTTSConfig | None = Field(None, alias="elevenlabs_tts")
     cartesia_tts: CartesiaTTSConfig | None = Field(None, alias="cartesia_tts")
     piper_tts: Optional[PiperTTSConfig] = Field(None, alias="piper_tts")
+    f5_tts: Optional[F5TTSConfig] = Field(None, alias="f5_tts")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "tts_model": Description(
@@ -769,6 +830,7 @@ class TTSConfig(I18nMixin):
             en="Configuration for Cartesia TTS", zh="Cartesia TTS 配置"
         ),
         "piper_tts": Description(en="Configuration for Piper TTS", zh="Piper TTS 配置"),
+        "f5_tts": Description(en="Configuration for F5-TTS", zh="F5-TTS 配置"),
     }
 
     @model_validator(mode="after")
@@ -813,4 +875,6 @@ class TTSConfig(I18nMixin):
 
         elif tts_model == "piper_tts" and values.piper_tts is not None:
             values.piper_tts.model_validate(values.piper_tts.model_dump())
+        elif tts_model == "f5_tts" and values.f5_tts is not None:
+            values.f5_tts.model_validate(values.f5_tts.model_dump())
         return values

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -680,8 +680,6 @@ class CartesiaTTSConfig(I18nMixin):
     }
 
 
-
-
 class F5TTSConfig(I18nMixin):
     """Configuration for F5-TTS."""
 
@@ -738,6 +736,7 @@ class F5TTSConfig(I18nMixin):
             zh="Sway采样系数（-1 禁用）",
         ),
     }
+
 
 class TTSConfig(I18nMixin):
     """Configuration for Text-to-Speech."""

--- a/src/open_llm_vtuber/tts/f5_tts.py
+++ b/src/open_llm_vtuber/tts/f5_tts.py
@@ -1,0 +1,112 @@
+import os
+
+from loguru import logger
+
+from .tts_interface import TTSInterface
+
+
+class TTSEngine(TTSInterface):
+    """
+    F5-TTS engine implementation.
+
+    F5-TTS uses flow matching for faithful speech synthesis with voice cloning
+    via a reference audio sample.
+
+    Requires: pip install f5-tts
+    """
+
+    def __init__(
+        self,
+        ref_audio: str = "",
+        ref_text: str = "",
+        model: str = "F5TTS_v1_Base",
+        device: str = "",
+        remove_silence: bool = False,
+        speed: float = 1.0,
+        cross_fade_duration: float = 0.15,
+        nfe_step: int = 32,
+        cfg_strength: float = 2.0,
+        sway_sampling_coef: float = -1.0,
+    ):
+        """
+        Initialize F5-TTS engine.
+
+        Args:
+            ref_audio: Path to reference audio file for voice cloning.
+            ref_text: Transcription of the reference audio (leave empty for auto-transcription).
+            model: Model name (F5TTS_v1_Base, F5TTS_Base, E2TTS_Base).
+            device: Device to use (cuda, cpu, mps, xpu). Empty for auto-detect.
+            remove_silence: Whether to remove silence from generated audio.
+            speed: Speech speed multiplier (1.0 = normal).
+            cross_fade_duration: Cross-fade duration in seconds between chunks.
+            nfe_step: Number of function evaluations (higher = better quality, slower).
+            cfg_strength: Classifier-free guidance strength.
+            sway_sampling_coef: Sway sampling coefficient (-1 to disable).
+        """
+        try:
+            from f5_tts.api import F5TTS
+        except ImportError:
+            raise ImportError(
+                "F5-TTS is not installed. Install it with: pip install f5-tts"
+            )
+
+        self.ref_audio = ref_audio
+        self.ref_text = ref_text
+        self.remove_silence = remove_silence
+        self.speed = speed
+        self.cross_fade_duration = cross_fade_duration
+        self.nfe_step = nfe_step
+        self.cfg_strength = cfg_strength
+        self.sway_sampling_coef = sway_sampling_coef
+
+        device_arg = device if device else None
+
+        logger.info(f"Initializing F5-TTS with model: {model}")
+        self.tts = F5TTS(model=model, device=device_arg)
+        logger.info("F5-TTS initialized successfully.")
+
+    def generate_audio(self, text: str, file_name_no_ext=None) -> str:
+        """
+        Generate speech audio file using F5-TTS.
+
+        Args:
+            text: Text to synthesize.
+            file_name_no_ext: Output filename without extension (optional).
+
+        Returns:
+            Path to generated audio file.
+        """
+        try:
+            output_path = self.generate_cache_file_name(file_name_no_ext, "wav")
+
+            if not self.ref_audio:
+                raise ValueError(
+                    "F5-TTS requires a reference audio file. "
+                    "Please set 'ref_audio' in the f5_tts configuration."
+                )
+
+            wav, sr, spec = self.tts.infer(
+                ref_file=self.ref_audio,
+                ref_text=self.ref_text,
+                gen_text=text,
+                target_rms=0.1,
+                cross_fade_duration=self.cross_fade_duration,
+                nfe_step=self.nfe_step,
+                cfg_strength=self.cfg_strength,
+                sway_sampling_coef=self.sway_sampling_coef,
+                speed=self.speed,
+                remove_silence=self.remove_silence,
+                file_wave=output_path,
+                seed=None,
+            )
+
+            if not os.path.exists(output_path):
+                raise FileNotFoundError(
+                    f"Failed to generate audio file at {output_path}"
+                )
+
+            return output_path
+
+        except Exception as e:
+            logger.error(f"F5-TTS failed to generate audio: {e}")
+            raise RuntimeError(f"Failed to generate audio with F5-TTS: {e}")

--- a/src/open_llm_vtuber/tts/f5_tts.py
+++ b/src/open_llm_vtuber/tts/f5_tts.py
@@ -109,4 +109,4 @@ class TTSEngine(TTSInterface):
 
         except Exception as e:
             logger.error(f"F5-TTS failed to generate audio: {e}")
-            raise RuntimeError(f"Failed to generate audio with F5-TTS: {e}")
+            raise RuntimeError(f"Failed to generate audio with F5-TTS: {e}") from e

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -1,11 +1,41 @@
+"""TTS engine factory for dynamic engine instantiation.
+
+Provides a factory pattern for creating TTS engine instances based on
+configuration-specified engine types.
+"""
+
 from typing import Type
 from .tts_interface import TTSInterface
 
 
 class TTSFactory:
+    """Factory for creating TTS engine instances by engine type name."""
+
     @staticmethod
-    def get_tts_engine(engine_type, **kwargs) -> Type[TTSInterface]:
+    def get_tts_engine(engine_type: str, **kwargs) -> Type[TTSInterface]:
+        """Instantiate and return a TTS engine based on the given engine type.
+
+        Args:
+            engine_type: The TTS engine identifier (e.g. 'azure_tts', 'f5_tts').
+            **kwargs: Engine-specific configuration parameters.
+
+        Returns:
+            An instance of the requested TTS engine.
+
+        Raises:
+            ValueError: If the engine type is not recognized.
+        """
         if engine_type == "azure_tts":
+            from .azure_tts import TTSEngine as AzureTTSEngine
+
+            return AzureTTSEngine(
+                kwargs.get("api_key"),
+                kwargs.get("region"),
+                kwargs.get("voice"),
+                kwargs.get("pitch"),
+                kwargs.get("rate"),
+            )
+if engine_type == "azure_tts":
             from .azure_tts import TTSEngine as AzureTTSEngine
 
             return AzureTTSEngine(

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -35,16 +35,6 @@ class TTSFactory:
                 kwargs.get("pitch"),
                 kwargs.get("rate"),
             )
-if engine_type == "azure_tts":
-            from .azure_tts import TTSEngine as AzureTTSEngine
-
-            return AzureTTSEngine(
-                kwargs.get("api_key"),
-                kwargs.get("region"),
-                kwargs.get("voice"),
-                kwargs.get("pitch"),
-                kwargs.get("rate"),
-            )
         elif engine_type == "bark_tts":
             from .bark_tts import TTSEngine as BarkTTSEngine
 

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -211,6 +211,21 @@ class TTSFactory:
                 normalize_audio=kwargs.get("normalize_audio"),
                 use_cuda=kwargs.get("use_cuda"),
             )
+        elif engine_type == "f5_tts":
+            from .f5_tts import TTSEngine as F5TTSEngine
+
+            return F5TTSEngine(
+                ref_audio=kwargs.get("ref_audio", ""),
+                ref_text=kwargs.get("ref_text", ""),
+                model=kwargs.get("model", "F5TTS_v1_Base"),
+                device=kwargs.get("device", ""),
+                remove_silence=kwargs.get("remove_silence", False),
+                speed=kwargs.get("speed", 1.0),
+                cross_fade_duration=kwargs.get("cross_fade_duration", 0.15),
+                nfe_step=kwargs.get("nfe_step", 32),
+                cfg_strength=kwargs.get("cfg_strength", 2.0),
+                sway_sampling_coef=kwargs.get("sway_sampling_coef", -1.0),
+            )
         else:
             raise ValueError(f"Unknown TTS engine type: {engine_type}")
 


### PR DESCRIPTION
## Summary

Adds [F5-TTS](https://github.com/SWivid/F5-TTS) as a new TTS engine option. F5-TTS uses flow matching for faithful speech synthesis with voice cloning via a reference audio sample.

Closes #101

## Changes

- **`src/open_llm_vtuber/tts/f5_tts.py`** — New TTS engine implementing `TTSInterface`
- **`src/open_llm_vtuber/tts/tts_factory.py`** — Registered `f5_tts` engine in factory
- **`src/open_llm_vtuber/config_manager/tts.py`** — Added `F5TTSConfig` with i18n descriptions
- **`src/open_llm_vtuber/config_manager/__init__.py`** — Exported `F5TTSConfig`
- **`config_templates/conf.default.yaml`** — Added F5-TTS config section
- **`config_templates/conf.ZH.default.yaml`** — Added F5-TTS config section (Chinese)

## Configuration Options

| Option | Default | Description |
|--------|---------|-------------|
| `ref_audio` | *required* | Path to reference audio for voice cloning |
| `ref_text` | `''` | Transcription of reference audio (empty = auto) |
| `model` | `F5TTS_v1_Base` | Model: `F5TTS_v1_Base`, `F5TTS_Base`, `E2TTS_Base` |
| `device` | `''` | Device: `cuda`, `cpu`, `mps`, `xpu` (empty = auto) |
| `remove_silence` | `false` | Remove silence from generated audio |
| `speed` | `1.0` | Speech speed multiplier |
| `cross_fade_duration` | `0.15` | Cross-fade duration between chunks (seconds) |
| `nfe_step` | `32` | Number of function evaluations (quality vs speed) |
| `cfg_strength` | `2.0` | Classifier-free guidance strength |
| `sway_sampling_coef` | `-1.0` | Sway sampling coefficient (-1 to disable) |

## Installation

```bash
pip install f5-tts
```

## Sample Config

```yaml
tts_model: f5_tts
f5_tts:
  ref_audio: 'path/to/reference.wav'
  ref_text: ''
  model: 'F5TTS_v1_Base'
  device: ''
  remove_silence: false
  speed: 1.0
  cross_fade_duration: 0.15
  nfe_step: 32
  cfg_strength: 2.0
  sway_sampling_coef: -1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an F5-TTS text-to-speech engine with voice cloning (reference audio and optional reference text).
  * Extended the TTS backend selector to include **f5_tts**.
  * Introduced **f5_tts** configuration options: model selection, device auto-detection, silence removal, and generation tuning (speed, cross-fade, sampling steps, guidance strength, sway sampling).
* **Updates**
  * Updated default configuration templates to recognize and document **f5_tts**.
  * Exposed the new F5-TTS configuration through the configuration manager for simplified setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->