### PR TITLE
fix: contain per-sentence TTS failures so one bad sentence doesn't abort the turn (#384)

### DIFF
--- a/src/open_llm_vtuber/conversations/conversation_utils.py
+++ b/src/open_llm_vtuber/conversations/conversation_utils.py
@@ -70,7 +70,9 @@ async def process_agent_output(
         else:
             logger.warning(f"Unknown output type: {type(output)}")
     except Exception as e:
-        logger.error(f"Error processing agent output: {e}")
+        logger.opt(exception=True).error(
+            f"Error processing agent output ({type(e).__name__}: {e})"
+        )
         await websocket_send(
             json.dumps(
                 {"type": "error", "message": f"Error processing response: {str(e)}"}

--- a/src/open_llm_vtuber/conversations/conversation_utils.py
+++ b/src/open_llm_vtuber/conversations/conversation_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 from typing import Optional, Union, Any, List, Dict
 import numpy as np
@@ -167,7 +166,7 @@ async def finalize_conversation_turn(
 ) -> None:
     """Finalize a conversation turn"""
     if tts_manager.task_list:
-        await asyncio.gather(*tts_manager.task_list)
+        await tts_manager.wait_for_tasks()
         await websocket_send(json.dumps({"type": "backend-synth-complete"}))
 
         response = await message_handler.wait_for_response(

--- a/src/open_llm_vtuber/conversations/group_conversation.py
+++ b/src/open_llm_vtuber/conversations/group_conversation.py
@@ -129,7 +129,9 @@ async def process_group_conversation(
                     metadata=current_metadata,
                 )
             except Exception as e:
-                logger.error(f"Error in group member turn: {e}")
+                logger.opt(exception=True).error(
+                    f"Error in group member turn ({type(e).__name__}: {e})"
+                )
                 await handle_member_error(
                     broadcast_func, group_members, f"Error in conversation: {str(e)}"
                 )
@@ -140,7 +142,11 @@ async def process_group_conversation(
         )
         raise
     except Exception as e:
-        logger.error(f"Error in group conversation chain: {e}")
+        # Log type and traceback: some exceptions stringify to "" and the
+        # bare message made this branch undiagnosable (#384).
+        logger.opt(exception=True).error(
+            f"Error in group conversation chain ({type(e).__name__}: {e})"
+        )
         await handle_member_error(
             broadcast_func, group_members, f"Fatal error in conversation: {str(e)}"
         )
@@ -268,7 +274,7 @@ async def handle_group_member_turn(
     )
 
     if tts_manager.task_list:
-        await asyncio.gather(*tts_manager.task_list)
+        await tts_manager.wait_for_tasks()
         await current_ws_send(json.dumps({"type": "backend-synth-complete"}))
 
         broadcast_ctx = BroadcastContext(

--- a/src/open_llm_vtuber/conversations/single_conversation.py
+++ b/src/open_llm_vtuber/conversations/single_conversation.py
@@ -137,9 +137,10 @@ async def process_single_conversation(
             # full_response will contain partial response before error
         # --- End processing agent response ---
 
-        # Wait for any pending TTS tasks
+        # Wait for any pending TTS tasks. Failed sentences are logged and
+        # skipped (#384) so the turn still finalizes and gets stored.
         if tts_manager.task_list:
-            await asyncio.gather(*tts_manager.task_list)
+            await tts_manager.wait_for_tasks()
             await websocket_send(json.dumps({"type": "backend-synth-complete"}))
 
         await finalize_conversation_turn(
@@ -165,7 +166,11 @@ async def process_single_conversation(
         logger.info(f"🤡👍 Conversation {session_emoji} cancelled because interrupted.")
         raise
     except Exception as e:
-        logger.error(f"Error in conversation chain: {e}")
+        # Log type and traceback: some exceptions stringify to "" and the
+        # bare message made this branch undiagnosable (#384).
+        logger.opt(exception=True).error(
+            f"Error in conversation chain ({type(e).__name__}: {e})"
+        )
         await websocket_send(
             json.dumps({"type": "error", "message": f"Conversation error: {str(e)}"})
         )

--- a/src/open_llm_vtuber/conversations/tts_manager.py
+++ b/src/open_llm_vtuber/conversations/tts_manager.py
@@ -171,6 +171,31 @@ class TTSTaskManager:
             file_name_no_ext=f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{str(uuid.uuid4())[:8]}",
         )
 
+    async def wait_for_tasks(self) -> None:
+        """
+        Wait for all queued TTS tasks, containing failures instead of
+        propagating them.
+
+        A single failed sentence must not abort the whole turn: letting
+        the exception escape skips `backend-synth-complete` and history
+        storage, so the next turn behaves as if the conversation was
+        interrupted. Failures are logged with their exception type
+        because some exceptions raise with an empty message and would
+        otherwise be undiagnosable. Cancellation is control flow, not a
+        TTS failure, and is re-raised.
+        """
+        if not self.task_list:
+            return
+        results = await asyncio.gather(*self.task_list, return_exceptions=True)
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                logger.opt(exception=result).error(
+                    f"TTS task failed ({type(result).__name__}: {result}); "
+                    "continuing with the remaining sentences"
+                )
+
     def clear(self) -> None:
         """Clear all pending tasks and reset state"""
         self.task_list.clear()


### PR DESCRIPTION
Fixes #384

## The two problems reported

1. **`Error in conversation chain` with an empty message** — the handler logged only `str(e)`, which is empty for some exception types (`logger.error(f"Error in conversation chain: {e}")`), so there was no way to diagnose what actually failed.
2. **"the AI thinks it was interrupted" after a sentence's voice output fails** — the bare `asyncio.gather(*tts_manager.task_list)` re-raises the first task failure, which aborts the rest of the turn: `backend-synth-complete` is never sent, `finalize_conversation_turn` never runs, and the AI response is never stored to history. On the next turn the conversation context looks interrupted.

## Fix

**`TTSTaskManager.wait_for_tasks()`** (new): gathers with `return_exceptions=True` and logs each failure with its exception type and traceback, so one failed sentence costs only its own audio — the silent-payload fallback inside `_process_tts` already covers the display side — while the turn still finalizes, `backend-synth-complete` is sent, and the response is stored. `CancelledError` is re-raised: interruption is control flow, not a TTS failure. All three gather sites use it (`single_conversation`, `group_conversation`, `finalize_conversation_turn`).

**Diagnosable error logs**: the `Error in conversation chain` / `group member turn` / `group conversation chain` handlers now log via `logger.opt(exception=True)` with the exception type name (`RuntimeError: ...`), matching what the inner stream handler (`logger.exception`) already does. Empty-message exceptions are no longer invisible.

This is the "ignore the error / keep going" direction the reporter suggested, plus the logging needed to find the root cause when it does happen.

## Verification

- `ruff check` / `ruff format --check` clean on the touched files (removed a now-unused `asyncio` import flagged by ruff).
- Behavioral check of the new method: a task raising `RuntimeError("")` (empty message) is logged with its type and does **not** abort the gather; a cancelled task re-raises `CancelledError` so interruption semantics are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text-to-speech completion handling so pending TTS tasks are properly awaited, and individual synthesis failures no longer interrupt or block the rest of the conversation turn.

* **Improvements**
  * Upgraded conversation error reporting to include clearer exception details (type and message) and full stack traces, making issues easier to diagnose during live use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->