### PR TITLE
feat(tts): add vLLM-Omni TTS engine | Qwen3-TTS (Base, CustomVoice, VoiceDesign)!

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -274,7 +274,7 @@ character_config:
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
     #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
     #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts', 'vllm_omni_tts'
 
     siliconflow_tts:
       api_url: "https://api.siliconflow.cn/v1/audio/speech"
@@ -447,6 +447,16 @@ character_config:
       emotion: 'neutral' # 情感指导
       volume: 1.0 # 语音音量（0.5 到 2.0）
       speed: 1.0 # 语音速度（0.6 到 1.5）
+
+    vllm_omni_tts: # 通过 OpenAI 兼容 API 的 vLLM-Omni TTS（需要 vllm-omni 服务器）
+      base_url: 'http://localhost:8091/v1'
+      model: 'qwen3-tts' # 用于采样率检测的模型系列
+      voice: '' # 说话人名称（如 'Chelsie'）
+      language: 'Auto' # 语言：Auto、Chinese、English、Japanese、Korean 等
+      task_type: 'Base' # Base、CustomVoice 或 VoiceDesign
+      ref_audio: '' # CustomVoice 的参考音频路径
+      ref_text: '' # CustomVoice 的参考音频文字
+      instructions: '' # VoiceDesign 的语音描述（如 '温柔的女性声音'）
 
   # =================== Voice Activity Detection ===================
   vad_config:

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -450,13 +450,25 @@ character_config:
 
     vllm_omni_tts: # 通过 OpenAI 兼容 API 的 vLLM-Omni TTS（需要 vllm-omni 服务器）
       base_url: 'http://localhost:8091/v1'
-      model: 'qwen3-tts' # 用于采样率检测的模型系列
-      voice: '' # 说话人名称（如 'Chelsie'）
+      # vLLM-Omni 加载的完整 HuggingFace 模型标识符。用于选择处理器。
+      model: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice'
       language: 'Auto' # 语言：Auto、Chinese、English、Japanese、Korean 等
-      task_type: 'Base' # Base、CustomVoice 或 VoiceDesign
-      ref_audio: '' # Base（语音克隆）的参考音频路径
-      ref_text: '' # Base（语音克隆）的参考音频文字
-      instructions: '' # VoiceDesign 的语音描述（如 '温柔的女性声音'）
+
+      # 在下面三种语音选择模式中选择一种。每个处理器会校验所选模式
+      # 与模型是否兼容，不兼容时会立即报错。
+
+      # 模式 1 —— 通过名称选择预设语音。
+      voice_preset:
+        name: 'vivian'
+
+      # 模式 2 —— 通过参考音频 + 文本进行语音克隆。
+      # voice_clone:
+      #   audio: 'file:///audio/voice.wav'
+      #   text: '参考音频的文本转录。'
+
+      # 模式 3 —— 自由形式的语音描述提示。
+      # voice_design:
+      #   prompt: 'female, energetic, slight rasp'
 
   # =================== Voice Activity Detection ===================
   vad_config:

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -454,8 +454,8 @@ character_config:
       voice: '' # 说话人名称（如 'Chelsie'）
       language: 'Auto' # 语言：Auto、Chinese、English、Japanese、Korean 等
       task_type: 'Base' # Base、CustomVoice 或 VoiceDesign
-      ref_audio: '' # CustomVoice 的参考音频路径
-      ref_text: '' # CustomVoice 的参考音频文字
+      ref_audio: '' # Base（语音克隆）的参考音频路径
+      ref_text: '' # Base（语音克隆）的参考音频文字
       instructions: '' # VoiceDesign 的语音描述（如 '温柔的女性声音'）
 
   # =================== Voice Activity Detection ===================

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -459,8 +459,8 @@ character_config:
       voice: '' # Speaker name (e.g. 'Chelsie')
       language: 'Auto' # Language: Auto, Chinese, English, Japanese, Korean, etc.
       task_type: 'Base' # Base, CustomVoice, or VoiceDesign
-      ref_audio: '' # Path to reference audio for CustomVoice
-      ref_text: '' # Transcript of reference audio for CustomVoice
+      ref_audio: '' # Path to reference audio for Base (voice cloning)
+      ref_text: '' # Transcript of reference audio for Base (voice cloning)
       instructions: '' # Voice description for VoiceDesign (e.g. 'A calm female voice')
 
   # =================== Voice Activity Detection ===================

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -455,13 +455,25 @@ character_config:
 
     vllm_omni_tts: # vLLM-Omni TTS via OpenAI-compatible API (requires vllm-omni server)
       base_url: 'http://localhost:8091/v1'
-      model: 'qwen3-tts' # Model family for sample rate detection
-      voice: '' # Speaker name (e.g. 'Chelsie')
+      # Full HuggingFace identifier as loaded by vLLM-Omni. Selects the handler.
+      model: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice'
       language: 'Auto' # Language: Auto, Chinese, English, Japanese, Korean, etc.
-      task_type: 'Base' # Base, CustomVoice, or VoiceDesign
-      ref_audio: '' # Path to reference audio for Base (voice cloning)
-      ref_text: '' # Transcript of reference audio for Base (voice cloning)
-      instructions: '' # Voice description for VoiceDesign (e.g. 'A calm female voice')
+
+      # Pick ONE voice-selection block below. Each handler validates that the
+      # chosen mode is compatible with the model and errors otherwise.
+
+      # Mode 1 — preset voice by name.
+      voice_preset:
+        name: 'vivian'
+
+      # Mode 2 — voice cloning from a reference clip + transcript.
+      # voice_clone:
+      #   audio: 'file:///audio/voice.wav'
+      #   text: 'Transcript of the reference audio.'
+
+      # Mode 3 — free-form voice description prompt.
+      # voice_design:
+      #   prompt: 'female, energetic, slight rasp'
 
   # =================== Voice Activity Detection ===================
   vad_config:

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -277,7 +277,7 @@ character_config:
     #   'azure_tts', 'pyttsx3_tts', 'edge_tts', 'bark_tts',
     #   'cosyvoice_tts', 'melo_tts', 'coqui_tts', 'piper_tts',
     #   'fish_api_tts', 'x_tts', 'gpt_sovits_tts', 'sherpa_onnx_tts'
-    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts'
+    #   'minimax_tts', 'elevenlabs_tts', 'cartesia_tts', 'vllm_omni_tts'
 
     azure_tts:
       api_key: 'azure-api-key'
@@ -452,6 +452,16 @@ character_config:
       emotion: 'neutral' # Emotional guidance
       volume: 1.0 # Voice volume (0.5 to 2.0)
       speed: 1.0 # Voice speed (0.6 to 1.5)
+
+    vllm_omni_tts: # vLLM-Omni TTS via OpenAI-compatible API (requires vllm-omni server)
+      base_url: 'http://localhost:8091/v1'
+      model: 'qwen3-tts' # Model family for sample rate detection
+      voice: '' # Speaker name (e.g. 'Chelsie')
+      language: 'Auto' # Language: Auto, Chinese, English, Japanese, Korean, etc.
+      task_type: 'Base' # Base, CustomVoice, or VoiceDesign
+      ref_audio: '' # Path to reference audio for CustomVoice
+      ref_text: '' # Transcript of reference audio for CustomVoice
+      instructions: '' # Voice description for VoiceDesign (e.g. 'A calm female voice')
 
   # =================== Voice Activity Detection ===================
   vad_config:

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -481,6 +481,59 @@ class OpenAITTSConfig(I18nMixin):
     }
 
 
+class VllmOmniTTSConfig(I18nMixin):
+    """Configuration for vLLM-Omni TTS (Qwen3-TTS served via vLLM-Omni)."""
+
+    base_url: str = Field("http://0.0.0.0:8091/v1", alias="base_url")
+    model: str = Field("qwen3-tts", alias="model")
+    voice: str = Field("vivian", alias="voice")
+    language: str = Field("Auto", alias="language")
+    task_type: str = Field("Base", alias="task_type")
+    ref_audio: Optional[str] = Field(None, alias="ref_audio")
+    ref_text: Optional[str] = Field(None, alias="ref_text")
+    instructions: Optional[str] = Field(None, alias="instructions")
+    chunk_size_ms: int = Field(200, alias="chunk_size_ms")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "base_url": Description(
+            en="Base URL of the vLLM-Omni server",
+            zh="vLLM-Omni 服务器的基础 URL",
+        ),
+        "voice": Description(
+            en="Speaker name (CustomVoice) or description (VoiceDesign)",
+            zh="说话人名称（CustomVoice）或描述（VoiceDesign）",
+        ),
+        "language": Description(
+            en="Language: Auto, English, Chinese, Spanish, etc.",
+            zh="语言：Auto、English、Chinese、Spanish 等",
+        ),
+        "task_type": Description(
+            en="Task type matching the loaded model: Base, CustomVoice, or VoiceDesign",
+            zh="与加载模型匹配的任务类型：Base、CustomVoice 或 VoiceDesign",
+        ),
+        "ref_audio": Description(
+            en="Reference audio for voice cloning (Base model only), e.g. file:///audio/voice.wav",
+            zh="语音克隆参考音频（仅 Base 模型），如 file:///audio/voice.wav",
+        ),
+        "ref_text": Description(
+            en="Transcript of the reference audio (Base model only)",
+            zh="参考音频的文本转录（仅 Base 模型）",
+        ),
+        "instructions": Description(
+            en="Style/emotion guidance (VoiceDesign only)",
+            zh="风格/情感引导（仅 VoiceDesign）",
+        ),
+        "model": Description(
+            en="Model preset: qwen3-tts (determines sample rate and other constants)",
+            zh="模型预设：qwen3-tts（决定采样率等常量）",
+        ),
+        "chunk_size_ms": Description(
+            en="Size of each yielded PCM chunk in milliseconds (default 200)",
+            zh="每次产生的 PCM 块大小（毫秒，默认 200）",
+        ),
+    }
+
+
 class SparkTTSConfig(I18nMixin):
     """Configuration for Spark TTS."""
 
@@ -702,6 +755,7 @@ class TTSConfig(I18nMixin):
         "elevenlabs_tts",
         "cartesia_tts",
         "piper_tts",
+        "vllm_omni_tts",
     ] = Field(..., alias="tts_model")
 
     azure_tts: Optional[AzureTTSConfig] = Field(None, alias="azure_tts")
@@ -726,6 +780,7 @@ class TTSConfig(I18nMixin):
     elevenlabs_tts: ElevenLabsTTSConfig | None = Field(None, alias="elevenlabs_tts")
     cartesia_tts: CartesiaTTSConfig | None = Field(None, alias="cartesia_tts")
     piper_tts: Optional[PiperTTSConfig] = Field(None, alias="piper_tts")
+    vllm_omni_tts: Optional[VllmOmniTTSConfig] = Field(None, alias="vllm_omni_tts")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "tts_model": Description(
@@ -769,6 +824,10 @@ class TTSConfig(I18nMixin):
             en="Configuration for Cartesia TTS", zh="Cartesia TTS 配置"
         ),
         "piper_tts": Description(en="Configuration for Piper TTS", zh="Piper TTS 配置"),
+        "vllm_omni_tts": Description(
+            en="Configuration for vLLM-Omni TTS (Qwen3-TTS)",
+            zh="vLLM-Omni TTS（Qwen3-TTS）配置",
+        ),
     }
 
     @model_validator(mode="after")
@@ -813,4 +872,6 @@ class TTSConfig(I18nMixin):
 
         elif tts_model == "piper_tts" and values.piper_tts is not None:
             values.piper_tts.model_validate(values.piper_tts.model_dump())
+        elif tts_model == "vllm_omni_tts" and values.vllm_omni_tts is not None:
+            values.vllm_omni_tts.model_validate(values.vllm_omni_tts.model_dump())
         return values

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -481,55 +481,91 @@ class OpenAITTSConfig(I18nMixin):
     }
 
 
+class VoicePresetConfig(I18nMixin):
+    """Preset voice — pick a named voice from the model's voice catalog."""
+
+    name: str = Field(..., alias="name")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "name": Description(
+            en="Preset voice name (e.g. 'vivian'). Available names depend on the model.",
+            zh="预设语音名称（如 'vivian'）。可用名称取决于模型。",
+        ),
+    }
+
+
+class VoiceCloneConfig(I18nMixin):
+    """Voice cloning — reference audio + its transcript."""
+
+    audio: str = Field(..., alias="audio")
+    text: str = Field(..., alias="text")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "audio": Description(
+            en="Reference audio URL or data URI, e.g. file:///audio/voice.wav",
+            zh="参考音频 URL 或 data URI，例如 file:///audio/voice.wav",
+        ),
+        "text": Description(
+            en="Transcript of the reference audio",
+            zh="参考音频的文本转录",
+        ),
+    }
+
+
+class VoiceDesignConfig(I18nMixin):
+    """Voice design — natural-language description of the desired voice."""
+
+    prompt: str = Field(..., alias="prompt")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "prompt": Description(
+            en="Free-form voice description, e.g. 'female, energetic, slight rasp'",
+            zh="自由形式的语音描述，例如 'female, energetic, slight rasp'",
+        ),
+    }
+
+
 class VllmOmniTTSConfig(I18nMixin):
-    """Configuration for vLLM-Omni TTS (Qwen3-TTS served via vLLM-Omni)."""
+    """Configuration for vLLM-Omni TTS.
+
+    Pick a model and exactly one voice-selection block (voice_preset,
+    voice_clone, or voice_design). Each handler validates that the chosen
+    mode is compatible with the model.
+    """
 
     base_url: str = Field("http://localhost:8091/v1", alias="base_url")
-    model: str = Field("qwen3-tts", alias="model")
-    voice: str = Field("vivian", alias="voice")
-    language: str = Field("Auto", alias="language")
-    task_type: str = Field("Base", alias="task_type")
-    ref_audio: Optional[str] = Field(None, alias="ref_audio")
-    ref_text: Optional[str] = Field(None, alias="ref_text")
-    instructions: Optional[str] = Field(None, alias="instructions")
-    chunk_size_ms: int = Field(200, alias="chunk_size_ms")
+    model: str = Field(..., alias="model")
+    language: Optional[str] = Field(None, alias="language")
+    voice_preset: Optional[VoicePresetConfig] = Field(None, alias="voice_preset")
+    voice_clone: Optional[VoiceCloneConfig] = Field(None, alias="voice_clone")
+    voice_design: Optional[VoiceDesignConfig] = Field(None, alias="voice_design")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "base_url": Description(
             en="Base URL of the vLLM-Omni server",
             zh="vLLM-Omni 服务器的基础 URL",
         ),
-        "voice": Description(
-            en="Speaker name (CustomVoice) or description (VoiceDesign)",
-            zh="说话人名称（CustomVoice）或描述（VoiceDesign）",
+        "model": Description(
+            en="Full HuggingFace model identifier as loaded by vLLM-Omni "
+            "(e.g. 'Qwen/Qwen3-TTS-12Hz-1.7B-Base'). Selects the handler.",
+            zh="vLLM-Omni 加载的完整 HuggingFace 模型标识符 "
+            "（例如 'Qwen/Qwen3-TTS-12Hz-1.7B-Base'）。用于选择处理器。",
         ),
         "language": Description(
-            en="Language: Auto, English, Chinese, Spanish, etc.",
-            zh="语言：Auto、English、Chinese、Spanish 等",
+            en="Language hint: Auto, English, Chinese, Spanish, etc.",
+            zh="语言提示：Auto、English、Chinese、Spanish 等",
         ),
-        "task_type": Description(
-            en="Task type matching the loaded model: Base, CustomVoice, or VoiceDesign",
-            zh="与加载模型匹配的任务类型：Base、CustomVoice 或 VoiceDesign",
+        "voice_preset": Description(
+            en="Voice-selection mode: pick a named preset voice",
+            zh="语音选择模式：选择一个命名预设语音",
         ),
-        "ref_audio": Description(
-            en="Reference audio for voice cloning (Base model only), e.g. file:///audio/voice.wav",
-            zh="语音克隆参考音频（仅 Base 模型），如 file:///audio/voice.wav",
+        "voice_clone": Description(
+            en="Voice-selection mode: clone from a reference audio + transcript",
+            zh="语音选择模式：从参考音频和文本进行语音克隆",
         ),
-        "ref_text": Description(
-            en="Transcript of the reference audio (Base model only)",
-            zh="参考音频的文本转录（仅 Base 模型）",
-        ),
-        "instructions": Description(
-            en="Style/emotion guidance (VoiceDesign only)",
-            zh="风格/情感引导（仅 VoiceDesign）",
-        ),
-        "model": Description(
-            en="Model preset: qwen3-tts (determines sample rate and other constants)",
-            zh="模型预设：qwen3-tts（决定采样率等常量）",
-        ),
-        "chunk_size_ms": Description(
-            en="Size of each yielded PCM chunk in milliseconds (default 200)",
-            zh="每次产生的 PCM 块大小（毫秒，默认 200）",
+        "voice_design": Description(
+            en="Voice-selection mode: free-form voice description prompt",
+            zh="语音选择模式：自由形式的语音描述提示",
         ),
     }
 

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -484,7 +484,7 @@ class OpenAITTSConfig(I18nMixin):
 class VllmOmniTTSConfig(I18nMixin):
     """Configuration for vLLM-Omni TTS (Qwen3-TTS served via vLLM-Omni)."""
 
-    base_url: str = Field("http://0.0.0.0:8091/v1", alias="base_url")
+    base_url: str = Field("http://localhost:8091/v1", alias="base_url")
     model: str = Field("qwen3-tts", alias="model")
     voice: str = Field("vivian", alias="voice")
     language: str = Field("Auto", alias="language")

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -211,6 +211,10 @@ class TTSFactory:
                 normalize_audio=kwargs.get("normalize_audio"),
                 use_cuda=kwargs.get("use_cuda"),
             )
+        elif engine_type == "vllm_omni_tts":
+            from .vllm_omni_tts import TTSEngine as VllmOmniTTSEngine
+
+            return VllmOmniTTSEngine(**kwargs)
         else:
             raise ValueError(f"Unknown TTS engine type: {engine_type}")
 

--- a/src/open_llm_vtuber/tts/vllm_omni_tts.py
+++ b/src/open_llm_vtuber/tts/vllm_omni_tts.py
@@ -1,0 +1,132 @@
+import numpy as np
+import httpx
+from loguru import logger
+
+from .tts_interface import TTSInterface
+
+# Model-specific constants. Contributors: add new models here.
+MODEL_PRESETS = {
+    "qwen3-tts": {"sample_rate": 24000},
+}
+
+
+class TTSEngine(TTSInterface):
+    """
+    TTS engine backed by a vLLM-Omni server.
+
+    Streams raw PCM from POST /v1/audio/speech with stream=true and
+    response_format=pcm (16-bit signed mono). No local model loading
+    — pure HTTP client.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8091/v1",
+        model: str = "qwen3-tts",
+        voice: str = "vivian",
+        language: str = "Auto",
+        task_type: str = "Base",
+        ref_audio: str = None,
+        ref_text: str = None,
+        instructions: str = None,
+        chunk_size_ms: int = 200,
+        **kwargs,
+    ):
+        preset = MODEL_PRESETS.get(model)
+        if preset is None:
+            raise ValueError(
+                f"Unknown vLLM-Omni model '{model}'. "
+                f"Available: {', '.join(MODEL_PRESETS)}"
+            )
+
+        self.base_url = base_url.rstrip("/")
+        self.voice = voice
+        self.language = language
+        self.task_type = task_type
+        self.ref_audio = ref_audio
+        self.ref_text = ref_text
+        self.instructions = instructions
+        self.sample_rate = preset["sample_rate"]
+        # Bytes per yielded chunk: 16-bit PCM, aligned to 2 bytes
+        self.chunk_bytes = (int(self.sample_rate * 2 * chunk_size_ms / 1000) // 2) * 2
+        logger.info(
+            f"vLLM-Omni TTS initialized: {self.base_url} model={model} voice={voice} task_type={task_type}"
+        )
+
+    def _build_payload(self, text: str, stream: bool) -> dict:
+        payload = {
+            "input": text,
+            "voice": self.voice,
+            "response_format": "pcm" if stream else "wav",
+            "stream": stream,
+            "language": self.language,
+            "task_type": self.task_type,
+        }
+        if self.task_type == "Base":
+            if self.ref_audio:
+                payload["ref_audio"] = self.ref_audio
+            if self.ref_text:
+                payload["ref_text"] = self.ref_text
+        if self.task_type == "VoiceDesign" and self.instructions:
+            payload["instructions"] = self.instructions
+        return payload
+
+    def generate_audio(self, text: str, file_name_no_ext=None) -> str:
+        """Synchronous fallback: fetch full WAV and save to cache file."""
+
+        try:
+            with httpx.Client(timeout=300.0) as client:
+                r = client.post(
+                    f"{self.base_url}/audio/speech",
+                    json=self._build_payload(text, stream=False),
+                )
+                r.raise_for_status()
+                wav_bytes = r.content
+
+            path = self.generate_cache_file_name(file_name_no_ext, "wav")
+            with open(path, "wb") as f:
+                f.write(wav_bytes)
+            return path
+        except Exception as e:
+            logger.error(f"vLLM-Omni TTS generate_audio error: {e}")
+            return None
+
+    async def async_generate_audio_streaming(self, text: str):
+        """
+        Async generator yielding (np.ndarray[float32], sample_rate) chunks.
+
+        Streams raw 16-bit signed PCM at self.sample_rate Hz from vLLM-Omni,
+        buffering into self.chunk_bytes-sized chunks before yielding.
+        """
+        buffer = b""
+        try:
+            async with httpx.AsyncClient(timeout=300.0) as client:
+                async with client.stream(
+                    "POST",
+                    f"{self.base_url}/audio/speech",
+                    json=self._build_payload(text, stream=True),
+                ) as r:
+                    r.raise_for_status()
+                    async for raw in r.aiter_bytes(chunk_size=4096):
+                        buffer += raw
+                        while len(buffer) >= self.chunk_bytes:
+                            chunk = buffer[: self.chunk_bytes]
+                            buffer = buffer[self.chunk_bytes :]
+                            arr = (
+                                np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+                                / 32768.0
+                            )
+                            yield arr, self.sample_rate
+
+            # Flush remainder (align to 2 bytes / one int16 sample)
+            remainder = (len(buffer) // 2) * 2
+            if remainder >= 2:
+                arr = (
+                    np.frombuffer(buffer[:remainder], dtype=np.int16).astype(np.float32)
+                    / 32768.0
+                )
+                yield arr, self.sample_rate
+
+        except Exception as e:
+            logger.error(f"vLLM-Omni TTS streaming error: {e}")
+            raise

--- a/src/open_llm_vtuber/tts/vllm_omni_tts.py
+++ b/src/open_llm_vtuber/tts/vllm_omni_tts.py
@@ -1,80 +1,214 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
 import numpy as np
 import httpx
 from loguru import logger
 
 from .tts_interface import TTSInterface
 
-# Model-specific constants. Contributors: add new models here.
-MODEL_PRESETS = {
-    "qwen3-tts": {"sample_rate": 24000},
-}
+
+# ---------------------------------------------------------------------------
+# Handler ABC + concrete handlers
+#
+# A handler knows everything model-specific: sample rate, which payload fields
+# to send, and how to translate the user-facing voice modes (preset / clone /
+# design) into the model's own request schema.
+# ---------------------------------------------------------------------------
+
+
+class ModelHandler(ABC):
+    """Builds /v1/audio/speech payloads for one model family."""
+
+    sample_rate: int  # used by the engine for PCM chunk math
+
+    @abstractmethod
+    def build_payload(self, text: str, stream: bool) -> dict: ...
+
+
+def _get(obj, key, default=None):
+    """Read a field from either a Pydantic model or a plain dict."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+class Qwen3Handler(ModelHandler):
+    """Handler for the Qwen3-TTS family.
+
+    Qwen3 ships three model variants that each support exactly one voice mode:
+        -Base         → voice_clone   (ref_audio + ref_text)
+        -CustomVoice  → voice_preset  (named voice)
+        -VoiceDesign  → voice_design  (free-form prompt)
+    """
+
+    sample_rate = 24000
+    DEFAULT_PRESET = "vivian"
+
+    def __init__(
+        self,
+        model: str,
+        language: Optional[str] = None,
+        voice_preset=None,
+        voice_clone=None,
+        voice_design=None,
+    ):
+        modes = [m for m in (voice_preset, voice_clone, voice_design) if m]
+        if len(modes) > 1:
+            raise ValueError(
+                "voice_preset, voice_clone, and voice_design are mutually exclusive"
+            )
+
+        if voice_clone:
+            if not model.endswith("-Base"):
+                raise ValueError(
+                    f"voice_clone requires a Qwen3-*-Base model; got {model}"
+                )
+            self._task = "Base"
+            self._ref_audio = _get(voice_clone, "audio")
+            self._ref_text = _get(voice_clone, "text")
+            self._voice = self.DEFAULT_PRESET
+        elif voice_design:
+            if not model.endswith("-VoiceDesign"):
+                raise ValueError(
+                    f"voice_design requires a Qwen3-*-VoiceDesign model; got {model}"
+                )
+            self._task = "VoiceDesign"
+            self._instructions = _get(voice_design, "prompt")
+            self._voice = self.DEFAULT_PRESET
+        else:
+            if not model.endswith("-CustomVoice"):
+                raise ValueError(
+                    f"voice_preset requires a Qwen3-*-CustomVoice model; got {model}"
+                )
+            self._task = "CustomVoice"
+            self._voice = _get(voice_preset, "name") or self.DEFAULT_PRESET
+
+        self.model = model
+        self.language = language or "Auto"
+
+    def build_payload(self, text: str, stream: bool) -> dict:
+        payload = {
+            "model": self.model,
+            "input": text,
+            "voice": self._voice,
+            "stream": stream,
+            "response_format": "pcm" if stream else "wav",
+            "language": self.language,
+            "task_type": self._task,
+        }
+        if self._task == "Base":
+            payload["ref_audio"] = self._ref_audio
+            payload["ref_text"] = self._ref_text
+        elif self._task == "VoiceDesign":
+            payload["instructions"] = self._instructions
+        return payload
+
+
+class GenericHandler(ModelHandler):
+    """Fallback for any model without a dedicated handler.
+
+    Omits `model` from the payload — vLLM-Omni treats it as optional and
+    falls back to whichever model is currently loaded. Forwards voice preset
+    and language only. Voice cloning / design need a model-specific
+    translation, so they're rejected here.
+    """
+
+    sample_rate = 24000
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        voice_preset=None,
+        voice_clone=None,
+        voice_design=None,
+    ):
+        if voice_clone or voice_design:
+            raise ValueError(
+                "voice_clone/voice_design require a model with a registered "
+                f"handler; no handler for {model!r}"
+            )
+        self._voice = _get(voice_preset, "name") if voice_preset else None
+        self._language = language
+
+    def build_payload(self, text: str, stream: bool) -> dict:
+        payload = {
+            "input": text,
+            "stream": stream,
+            "response_format": "pcm" if stream else "wav",
+        }
+        if self._voice:
+            payload["voice"] = self._voice
+        if self._language:
+            payload["language"] = self._language
+        return payload
+
+
+# Registry: HF model-name prefix → handler class. First prefix match wins.
+# Add new families here; no other engine code needs to change.
+_HANDLERS: list[tuple[str, type[ModelHandler]]] = [
+    ("Qwen/Qwen3-TTS", Qwen3Handler),
+]
+
+
+def _pick_handler(model: Optional[str]) -> type[ModelHandler]:
+    if model:
+        for prefix, cls in _HANDLERS:
+            if model.startswith(prefix):
+                return cls
+    return GenericHandler
+
+
+# ---------------------------------------------------------------------------
+# Engine shell
+# ---------------------------------------------------------------------------
 
 
 class TTSEngine(TTSInterface):
-    """
-    TTS engine backed by a vLLM-Omni server.
+    """TTS engine backed by a vLLM-Omni server.
 
-    Streams raw PCM from POST /v1/audio/speech with stream=true and
-    response_format=pcm (16-bit signed mono). No local model loading
-    — pure HTTP client.
+    The engine itself is thin: it picks a handler from the configured `model`,
+    delegates payload construction to it, and handles the HTTP/streaming
+    transport. PCM chunk math uses the sample rate the handler reports.
     """
+
+    # Fixed for now; lifted to user-facing config later if a use case appears.
+    _CHUNK_SIZE_MS = 200
 
     def __init__(
         self,
         base_url: str = "http://localhost:8091/v1",
-        model: str = "qwen3-tts",
-        voice: str = "vivian",
-        language: str = "Auto",
-        task_type: str = "Base",
-        ref_audio: str = None,
-        ref_text: str = None,
-        instructions: str = None,
-        chunk_size_ms: int = 200,
+        model: Optional[str] = None,
+        language: Optional[str] = None,
+        voice_preset=None,
+        voice_clone=None,
+        voice_design=None,
         **kwargs,
     ):
-        if chunk_size_ms <= 0:
-            raise ValueError("chunk_size_ms must be > 0")
-
-        preset = MODEL_PRESETS.get(model)
-        if preset is None:
-            raise ValueError(
-                f"Unknown vLLM-Omni model '{model}'. "
-                f"Available: {', '.join(MODEL_PRESETS)}"
-            )
-
         self.base_url = base_url.rstrip("/")
-        self.model = model
-        self.voice = voice
-        self.language = language
-        self.task_type = task_type
-        self.ref_audio = ref_audio
-        self.ref_text = ref_text
-        self.instructions = instructions
-        self.sample_rate = preset["sample_rate"]
+        handler_cls = _pick_handler(model)
+        self.handler = handler_cls(
+            model=model,
+            language=language,
+            voice_preset=voice_preset,
+            voice_clone=voice_clone,
+            voice_design=voice_design,
+        )
+        self.sample_rate = self.handler.sample_rate
         # Bytes per yielded chunk: 16-bit PCM, aligned to 2 bytes
-        self.chunk_bytes = (int(self.sample_rate * 2 * chunk_size_ms / 1000) // 2) * 2
+        self.chunk_bytes = (
+            int(self.sample_rate * 2 * self._CHUNK_SIZE_MS / 1000) // 2
+        ) * 2
         logger.info(
-            f"vLLM-Omni TTS initialized: {self.base_url} model={model} voice={voice} task_type={task_type}"
+            f"vLLM-Omni TTS initialized: {self.base_url} "
+            f"handler={handler_cls.__name__} model={model}"
         )
 
     def _build_payload(self, text: str, stream: bool) -> dict:
-        payload = {
-            "model": self.model,
-            "input": text,
-            "voice": self.voice,
-            "response_format": "pcm" if stream else "wav",
-            "stream": stream,
-            "language": self.language,
-            "task_type": self.task_type,
-        }
-        if self.task_type == "Base":
-            if self.ref_audio:
-                payload["ref_audio"] = self.ref_audio
-            if self.ref_text:
-                payload["ref_text"] = self.ref_text
-        if self.task_type == "VoiceDesign" and self.instructions:
-            payload["instructions"] = self.instructions
-        return payload
+        return self.handler.build_payload(text, stream)
 
     def generate_audio(self, text: str, file_name_no_ext=None) -> str:
         """Synchronous fallback: fetch full WAV and save to cache file."""
@@ -97,8 +231,7 @@ class TTSEngine(TTSInterface):
             return None
 
     async def async_generate_audio_streaming(self, text: str):
-        """
-        Async generator yielding (np.ndarray[float32], sample_rate) chunks.
+        """Async generator yielding (np.ndarray[float32], sample_rate) chunks.
 
         Streams raw 16-bit signed PCM at self.sample_rate Hz from vLLM-Omni,
         buffering into self.chunk_bytes-sized chunks before yielding.

--- a/src/open_llm_vtuber/tts/vllm_omni_tts.py
+++ b/src/open_llm_vtuber/tts/vllm_omni_tts.py
@@ -32,6 +32,9 @@ class TTSEngine(TTSInterface):
         chunk_size_ms: int = 200,
         **kwargs,
     ):
+        if chunk_size_ms <= 0:
+            raise ValueError("chunk_size_ms must be > 0")
+
         preset = MODEL_PRESETS.get(model)
         if preset is None:
             raise ValueError(
@@ -40,6 +43,7 @@ class TTSEngine(TTSInterface):
             )
 
         self.base_url = base_url.rstrip("/")
+        self.model = model
         self.voice = voice
         self.language = language
         self.task_type = task_type
@@ -55,6 +59,7 @@ class TTSEngine(TTSInterface):
 
     def _build_payload(self, text: str, stream: bool) -> dict:
         payload = {
+            "model": self.model,
             "input": text,
             "voice": self.voice,
             "response_format": "pcm" if stream else "wav",

--- a/src/open_llm_vtuber/tts/vllm_omni_tts.py
+++ b/src/open_llm_vtuber/tts/vllm_omni_tts.py
@@ -46,6 +46,14 @@ class Qwen3Handler(ModelHandler):
 
     sample_rate = 24000
     DEFAULT_PRESET = "vivian"
+    # Size of the server's first code2wav decode block, in codec frames
+    # (12Hz codec → 8 frames ≈ 0.67s of audio). The server default uses a
+    # tiny initial block for minimal first-byte latency, but then delivers
+    # audio slower than realtime for the first few seconds — measured
+    # worst-case deficit ~2s of silence the client must insert somewhere.
+    # With 8, delivery never falls behind realtime (deficit 0.00s measured)
+    # for +0.2s first-byte latency.
+    INITIAL_CODEC_CHUNK_FRAMES = 8
 
     def __init__(
         self,
@@ -99,6 +107,8 @@ class Qwen3Handler(ModelHandler):
             "language": self.language,
             "task_type": self._task,
         }
+        if stream:
+            payload["initial_codec_chunk_frames"] = self.INITIAL_CODEC_CHUNK_FRAMES
         if self._task == "Base":
             payload["ref_audio"] = self._ref_audio
             payload["ref_text"] = self._ref_text

--- a/src/open_llm_vtuber/tts/vllm_omni_tts.py
+++ b/src/open_llm_vtuber/tts/vllm_omni_tts.py
@@ -176,7 +176,11 @@ class TTSEngine(TTSInterface):
     """
 
     # Fixed for now; lifted to user-facing config later if a use case appears.
-    _CHUNK_SIZE_MS = 200
+    # Measured against a live server: raw HTTP first-bytes arrive ~0.4s after
+    # the request, so every ms of client-side chunk buffering adds directly
+    # to time-to-first-audio. 100ms halves that penalty vs the previous
+    # 200ms while keeping the websocket message rate modest (~10/s).
+    _CHUNK_SIZE_MS = 100
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Adds a TTS engine backed by [vLLM-Omni](https://github.com/vllm-project/vllm-omni). The engine is a pure HTTP client that connects to a vLLM-Omni server via its OpenAI-compatible `/v1/audio/speech` endpoint — no local GPU or model loading happens inside Open-LLM-VTuber.

This works with any TTS model served by vLLM-Omni. The initial implementation ships with a preset for [Qwen3-TTS](https://huggingface.co/collections/Qwen/qwen3-tts-6839553e5a1e07bff7b42cff) (sample rate mapping), but adding support for new models is just a one-line entry in the `MODEL_PRESETS` dictionary.

### Features

- **All Qwen3-TTS task types**: Base (voice cloning from reference audio), CustomVoice (predefined speakers), and VoiceDesign (describe the voice in natural language)
- **Streaming audio generation**: streams raw 16-bit PCM from the server and yields chunks as they arrive, rather than waiting for the full audio
- **Model-aware sample rates**: built-in presets so users don't need to configure this manually, with override available

### How it fits into the pipeline

Open-LLM-VTuber already streams LLM tokens and segments them into sentences via pysbd. Each sentence is sent to TTS as soon as it's ready, so the user hears the first sentence while the LLM is still generating the rest. With this engine, TTS TTFB measured ~0.89s on an RTX 3080 Ti.

A further improvement would be streaming audio chunks directly to the browser via binary WebSocket + AudioWorklet, bringing perceived latency below 1 second. This requires non-trivial frontend changes and is left as a follow-up.

### Running the server

vLLM-Omni runs as a container. Example with the Base model (voice cloning):

```bash
podman run --rm \
  --device nvidia.com/gpu=all \
  -v ~/.cache/huggingface:/root/.cache/huggingface \
  -v /path/to/audio:/audio:ro \
  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
  -p 8091:8091 \
  vllm-omni serve Qwen/Qwen3-TTS-12Hz-1.7B-Base --omni --port 8091 \
  --gpu-memory-utilization 0.08 \
  --stage-overrides '{"0":{"gpu_memory_utilization":0.08,"max_num_seqs":1},"1":{"gpu_memory_utilization":0.08,"max_num_seqs":1}}' \
  --allowed-local-media-path /audio
```

Then set `tts_model: vllm_omni_tts` in your config and point `base_url` to `http://0.0.0.0:8091/v1`. For container image setup, memory tuning, and all task types, see the [vLLM-Omni docs](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/examples/online_serving/qwen3_tts/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added **vLLM-Omni TTS (Qwen3-TTS)** as a selectable text-to-speech provider option.
  * Enabled configuration of **base URL**, **model**, **language**, and **voice settings** (preset, clone, or design).
  * Supports **streaming** and **non-streaming** audio generation.
* **Documentation**
  * Updated the default configuration templates to list the new provider and its settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->