### PR TITLE
fix(letta): repair streaming chat against current letta-client and server

### DIFF
--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -65,7 +65,11 @@ class LettaAgent(AgentInterface):
         payload = {"messages": messages, "stream_tokens": True}
         path = f"/v1/agents/{self.id}/messages/stream"
 
-        async with httpx.AsyncClient(base_url=self.url, timeout=None) as client:
+        # read=None — SSE streams hold the connection open between events.
+        # Other phases get finite ceilings so the agent fails fast if Letta
+        # is unreachable instead of hanging forever.
+        timeout = httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0)
+        async with httpx.AsyncClient(base_url=self.url, timeout=timeout) as client:
             async with client.stream("POST", path, json=payload) as response:
                 response.raise_for_status()
                 async for line in response.aiter_lines():

--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -1,4 +1,9 @@
+import json
 from typing import AsyncIterator, List, Dict, Any
+
+import httpx
+from loguru import logger
+
 from .agent_interface import AgentInterface
 from ..output_types import SentenceOutput
 from ..transformers import (
@@ -9,7 +14,6 @@ from ..transformers import (
 )
 from ...config_manager import TTSPreprocessorConfig
 from ..input_types import BatchInput, TextSource
-from letta_client import Letta
 
 
 class LettaAgent(AgentInterface):
@@ -29,7 +33,6 @@ class LettaAgent(AgentInterface):
     ):
         super().__init__()
         self.url = f"http://{host}:{port}"
-        self.client = Letta(base_url=self.url)
         self.id = id
         # Initialize decorator parameters
         self._tts_preprocessor_config = tts_preprocessor_config
@@ -57,36 +60,41 @@ class LettaAgent(AgentInterface):
     def handle_interrupt(self, heard_response: str) -> None:
         pass
 
-    async def generator_to_async(self, gen):
-        for item in gen:
-            yield item
-
     async def chat(self, input_data: BatchInput) -> AsyncIterator[SentenceOutput]:
         messages = self._to_messages(input_data)
-        stream = self.generator_to_async(
-            self.client.agents.messages.create_stream(
-                agent_id=self.id,
-                messages=messages,
-                stream_tokens=True,
-            )
-        )
+        payload = {"messages": messages, "stream_tokens": True}
+        path = f"/v1/agents/{self.id}/messages/stream"
 
-        complete_response = ""
-        async for token in stream:
-            if token.message_type == "reasoning_message":
-                # This part is reasoning information and should not be displayed
-                token = token.reasoning
-                continue
-            elif token.message_type == "assistant_message":
-                # This part is the result that needs to be displayed, it is the final result
-                # logger.info('Test message')
-                # logger.info(token)
-                token = token.content
-            else:
-                continue
+        async with httpx.AsyncClient(base_url=self.url, timeout=None) as client:
+            async with client.stream("POST", path, json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    data = line[len("data: ") :]
+                    if data == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
 
-            yield token
-            complete_response += token
+                    mtype = event.get("message_type")
+                    if mtype == "assistant_message":
+                        content = event.get("content", "")
+                        if isinstance(content, list):
+                            content = "".join(
+                                part.get("text", "")
+                                for part in content
+                                if isinstance(part, dict)
+                            )
+                        if content:
+                            yield content
+                    elif mtype == "error_message":
+                        logger.error(
+                            f"Letta error: {event.get('detail') or event.get('message')}"
+                        )
+                        break
 
     def _to_text_prompt(self, input_data: BatchInput) -> str:
         """


### PR DESCRIPTION
## Summary

Three independent bugs were preventing `LettaAgent` from sending any message through a self-hosted Letta server. Together they made the agent unusable end-to-end. This PR fixes all three with a single rewrite of `LettaAgent.chat()`.

## What was broken

1. **Method rename in `letta-client` ≥ 1.7.** `MessagesResource.create_stream(...)` was renamed to `MessagesResource.stream(...)`. The current code calls `create_stream` and fails immediately with `AttributeError: 'MessagesResource' object has no attribute 'create_stream'`.

2. **Sync client inside the asyncio loop.** `LettaAgent` used the synchronous `Letta` client. When called from uvicorn's async event loop, the blocking HTTP call held the loop hostage long enough for the server to reset the connection — surfacing as `httpx.RemoteProtocolError: Server disconnected without sending a response` even though the endpoint itself works fine when called directly.

3. **`assistant_message.content` is now a union.** In current `letta-client`, the field is typed `Union[str, List[LettaAssistantMessageContentUnion]]`. The previous code did `token = token.content` and yielded that directly — when the server returned content parts (a list), the agent yielded a list object into the sentence divider and crashed downstream.

## What this changes

Replace the `letta-client` streaming call with a direct `httpx.AsyncClient.stream()` SSE consumer in `src/open_llm_vtuber/agent/agents/letta_agent.py`. The new `chat()`:

- Posts to `/v1/agents/{id}/messages/stream` with `stream_tokens=True`.
- Parses each `data: …` SSE line, breaking on `[DONE]`.
- Yields `assistant_message.content` as a string (joining `TextContent` parts if the server returns the list form).
- Skips `reasoning_message` events (kept hidden from the user) and logs any `error_message` event.

This also incidentally avoids a separate `httpx + uvloop + IPv6 SSE` issue we hit when `host: 'localhost'` resolves to `::1` — the direct httpx call exposes the same problem, but it's at least solvable by configuring the Letta host as `127.0.0.1` in `conf.yaml`.

## Verification

Verified end-to-end against a self-hosted Letta `0.16.8` Podman container with a `letta_v1_agent` running on `ollama/gemma4:e4b`:

- Backend starts cleanly, frontend connects via WebSocket.
- Sending a user message produces a streamed reply that the sentence divider segments correctly and TTS plays back.
- Second message in the same session correctly carries over memory blocks (persona/human) stored server-side, confirming that conversation state is being threaded through.
- Server logs show a successful POST to `/v1/agents/{id}/messages/stream` with no `RemoteProtocolError` or `AttributeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by switching to direct HTTP-based token streaming for agent responses.
  * Enhanced error handling and logging for streaming failures to provide clearer messages during agent communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->