### PR TITLE
fix(letta): pass images to Letta API in native content-part format

### DIFF
--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -1,4 +1,8 @@
+import re
 from typing import AsyncIterator, List, Dict, Any
+
+from loguru import logger
+
 from .agent_interface import AgentInterface
 from ..output_types import SentenceOutput
 from ..transformers import (
@@ -109,19 +113,48 @@ class LettaAgent(AgentInterface):
 
         return "\n".join(message_parts)
 
+    @staticmethod
+    def _parse_data_url(data_url: str) -> tuple[str, str] | None:
+        """Parse a base64 data URL into (media_type, raw_base64)."""
+        match = re.match(r"^data:(image/\w+);base64,(.+)$", data_url)
+        if not match:
+            return None
+        return match.group(1), match.group(2)
+
     def _to_messages(self, input_data: BatchInput) -> List[Dict[str, Any]]:
         """
-        Prepare messages list without image support.
+        Prepare messages with image support in Letta's native content-part format.
         """
         messages = []
+        text_content = self._to_text_prompt(input_data)
 
         if input_data.images:
             content = []
-            text_content = self._to_text_prompt(input_data)
             content.append({"type": "text", "text": text_content})
+
+            for img_data in input_data.images:
+                if isinstance(img_data.data, str):
+                    parsed = self._parse_data_url(img_data.data)
+                    if parsed is not None:
+                        media_type, raw_b64 = parsed
+                        content.append({
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "data": raw_b64,
+                                "media_type": media_type,
+                            },
+                        })
+                    else:
+                        logger.warning(
+                            f"Unrecognised image data format, skipping. "
+                            f"Expected a data: URL, got {img_data.data[:80]}…"
+                        )
+                        content.append({"type": "text", "text": "[Image]"})
+
             user_message = {"role": "user", "content": content}
         else:
-            user_message = {"role": "user", "content": self._to_text_prompt(input_data)}
+            user_message = {"role": "user", "content": text_content}
 
         messages.append(user_message)
 

--- a/src/open_llm_vtuber/agent/agents/letta_agent.py
+++ b/src/open_llm_vtuber/agent/agents/letta_agent.py
@@ -114,12 +114,12 @@ class LettaAgent(AgentInterface):
         return "\n".join(message_parts)
 
     @staticmethod
-    def _parse_data_url(data_url: str) -> tuple[str, str] | None:
-        """Parse a base64 data URL into (media_type, raw_base64)."""
-        match = re.match(r"^data:(image/\w+);base64,(.+)$", data_url)
+    def _parse_data_url(data_url: str) -> str | None:
+        """Extract the raw base64 payload from a data URL."""
+        match = re.match(r"^data:image/[^;]+;base64,(.+)$", data_url)
         if not match:
             return None
-        return match.group(1), match.group(2)
+        return match.group(1)
 
     def _to_messages(self, input_data: BatchInput) -> List[Dict[str, Any]]:
         """
@@ -134,23 +134,30 @@ class LettaAgent(AgentInterface):
 
             for img_data in input_data.images:
                 if isinstance(img_data.data, str):
-                    parsed = self._parse_data_url(img_data.data)
-                    if parsed is not None:
-                        media_type, raw_b64 = parsed
-                        content.append({
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "data": raw_b64,
-                                "media_type": media_type,
-                            },
-                        })
+                    raw_b64 = self._parse_data_url(img_data.data)
+                    if raw_b64 is not None:
+                        content.append(
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "data": raw_b64,
+                                    "media_type": img_data.mime_type,
+                                },
+                            }
+                        )
                     else:
                         logger.warning(
                             f"Unrecognised image data format, skipping. "
                             f"Expected a data: URL, got {img_data.data[:80]}…"
                         )
                         content.append({"type": "text", "text": "[Image]"})
+                else:
+                    logger.warning(
+                        f"Unexpected image data type ({type(img_data.data).__name__}), "
+                        f"skipping."
+                    )
+                    content.append({"type": "text", "text": "[Image]"})
 
             user_message = {"role": "user", "content": content}
         else:


### PR DESCRIPTION
## Summary

The `LettaAgent._to_messages()` method checked for images but never actually included them in the message payload — the image data was silently dropped. The model always received just the text part, making it unable to see screen shares, camera captures, or uploaded images.

## What was broken

In `letta_agent.py:118-131`, the `if input_data.images:` branch created a `content` array but only appended the text portion — it never iterated `input_data.images` to add image content parts. Compare with `basic_memory_agent.py:_to_messages()` which correctly iterates images and appends `image_url` blocks.

## What this changes

Adds a `_parse_data_url()` helper and rewrites `_to_messages()` to:

- Always build a `content` parts array when images are present
- Parse each base64 data URL (e.g. `data:image/jpeg;base64,...`) into Letta's native content-part format:
  ```json
  {"type": "image", "source": {"type": "base64", "data": "...", "media_type": "image/jpeg"}}
  ```
- Fall back to a `[Image]` text placeholder for unrecognised formats
- Log a warning when an image cannot be parsed

## Verification

Tested end-to-end against a self-hosted Letta Podman container with a vision-capable model:

- Sending a screen-share image with "qué ves en pantalla?" now produces a correct description of the screen content
- The model no longer responds with "no veo ninguna imagen adjunta"
- Text-only conversations remain unaffected (the else-branch is unchanged)
- `ruff check` and `ruff format` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending image inputs alongside text in chat messages.
  * Images provided as base64 data URLs are now embedded into the outgoing message payload when recognized.

* **Bug Fixes**
  * Improved resilience for unsupported or invalid image strings by substituting a safe `"[Image]"` placeholder instead of disrupting message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->