### PR TITLE
feat(tts): stream TTS audio to the frontend chunk by chunk

### DIFF
--- a/src/open_llm_vtuber/conversations/tts_manager.py
+++ b/src/open_llm_vtuber/conversations/tts_manager.py
@@ -1,16 +1,40 @@
 import asyncio
 import json
 import re
+import time
 import uuid
 from datetime import datetime
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Union
 from loguru import logger
 
 from ..agent.output_types import DisplayText, Actions
 from ..live2d_model import Live2dModel
 from ..tts.tts_interface import TTSInterface
-from ..utils.stream_audio import prepare_audio_payload
+from ..utils.stream_audio import (
+    prepare_audio_payload,
+    prepare_stream_start_payload,
+    prepare_stream_chunk_payload,
+    prepare_stream_end_payload,
+)
 from .types import WebSocketSend
+
+
+class _StreamHandle:
+    """
+    A streamed-audio sentence occupying one sequence slot in the ordered
+    sender. Chunk payloads are produced by the TTS task and consumed by the
+    sender once this handle's sequence number is up; a ``None`` sentinel
+    marks the end of the stream.
+    """
+
+    def __init__(self, start_payload: Dict) -> None:
+        self.start_payload = start_payload
+        self.stream_id: str = start_payload["stream_id"]
+        self.chunks: asyncio.Queue[Optional[Dict]] = asyncio.Queue()
+
+    def finish(self) -> None:
+        """Signal that no more chunks will be produced."""
+        self.chunks.put_nowait(None)
 
 
 class TTSTaskManager:
@@ -19,8 +43,8 @@ class TTSTaskManager:
     def __init__(self) -> None:
         self.task_list: List[asyncio.Task] = []
         self._lock = asyncio.Lock()
-        # Queue to store ordered payloads
-        self._payload_queue: asyncio.Queue[Dict] = asyncio.Queue()
+        # Queue to store ordered payloads (complete dicts or _StreamHandles)
+        self._payload_queue: asyncio.Queue[Union[Dict, _StreamHandle]] = asyncio.Queue()
         # Task to handle sending payloads in order
         self._sender_task: Optional[asyncio.Task] = None
         # Counter for maintaining order
@@ -94,7 +118,7 @@ class TTSTaskManager:
         Process and send payloads in correct order.
         Runs continuously until all payloads are processed.
         """
-        buffered_payloads: Dict[int, Dict] = {}
+        buffered_payloads: Dict[int, Union[Dict, _StreamHandle]] = {}
 
         while True:
             try:
@@ -105,13 +129,34 @@ class TTSTaskManager:
                 # Send payloads in order
                 while self._next_sequence_to_send in buffered_payloads:
                     next_payload = buffered_payloads.pop(self._next_sequence_to_send)
-                    await websocket_send(json.dumps(next_payload))
+                    if isinstance(next_payload, _StreamHandle):
+                        await self._send_stream(next_payload, websocket_send)
+                    else:
+                        await websocket_send(json.dumps(next_payload))
                     self._next_sequence_to_send += 1
 
                 self._payload_queue.task_done()
 
             except asyncio.CancelledError:
                 break
+
+    async def _send_stream(
+        self, handle: _StreamHandle, websocket_send: WebSocketSend
+    ) -> None:
+        """
+        Send one streamed sentence: start payload, then chunks as they become
+        available from the TTS task, then the end payload. Blocks the ordered
+        sender until this stream completes, which keeps wire order strictly
+        sequential (later sentences keep synthesizing concurrently — their
+        chunks simply buffer in their own handles meanwhile).
+        """
+        await websocket_send(json.dumps(handle.start_payload))
+        while True:
+            chunk_payload = await handle.chunks.get()
+            if chunk_payload is None:
+                break
+            await websocket_send(json.dumps(chunk_payload))
+        await websocket_send(json.dumps(prepare_stream_end_payload(handle.stream_id)))
 
     async def _send_silent_payload(
         self,
@@ -137,6 +182,16 @@ class TTSTaskManager:
         sequence_number: int,
     ) -> None:
         """Process TTS generation and queue the result for ordered delivery"""
+        if callable(getattr(tts_engine, "async_generate_audio_streaming", None)):
+            await self._process_tts_streaming(
+                tts_text=tts_text,
+                display_text=display_text,
+                actions=actions,
+                tts_engine=tts_engine,
+                sequence_number=sequence_number,
+            )
+            return
+
         audio_file_path = None
         try:
             audio_file_path = await self._generate_audio(tts_engine, tts_text)
@@ -162,6 +217,66 @@ class TTSTaskManager:
             if audio_file_path:
                 tts_engine.remove_file(audio_file_path)
                 logger.debug("Audio cache file cleaned.")
+
+    async def _process_tts_streaming(
+        self,
+        tts_text: str,
+        display_text: DisplayText,
+        actions: Optional[Actions],
+        tts_engine: TTSInterface,
+        sequence_number: int,
+    ) -> None:
+        """
+        Stream TTS audio chunk by chunk instead of waiting for a full file.
+
+        The stream handle is enqueued at this sentence's sequence slot only
+        once the first chunk arrives (the sample rate is known then, and the
+        subtitle appears when audio is actually ready). If the engine fails
+        before producing any audio, fall back to a silent display payload.
+        """
+        stream_id = str(uuid.uuid4())
+        handle: Optional[_StreamHandle] = None
+        start_time = time.perf_counter()
+
+        logger.debug(f"🏃Streaming audio for '''{tts_text}'''...")
+        try:
+            async for chunk in tts_engine.async_generate_audio_streaming(tts_text):
+                chunk_payload, sample_rate = prepare_stream_chunk_payload(
+                    stream_id, chunk
+                )
+                if handle is None:
+                    logger.debug(
+                        f"First TTS chunk after {time.perf_counter() - start_time:.2f}s "
+                        f"for '''{tts_text}'''"
+                    )
+                    start_payload = prepare_stream_start_payload(
+                        stream_id=stream_id,
+                        sample_rate=sample_rate,
+                        display_text=display_text,
+                        actions=actions,
+                    )
+                    handle = _StreamHandle(start_payload)
+                    await self._payload_queue.put((handle, sequence_number))
+                handle.chunks.put_nowait(chunk_payload)
+
+        except Exception as e:
+            logger.error(f"Error streaming TTS audio: {e}")
+            if handle is None:
+                # Nothing was streamed — show the text silently so the
+                # sentence isn't lost and the sequence slot is filled.
+                payload = prepare_audio_payload(
+                    audio_path=None,
+                    display_text=display_text,
+                    actions=actions,
+                )
+                await self._payload_queue.put((payload, sequence_number))
+                return
+
+        finally:
+            # Always unblock the sender, including on mid-stream errors and
+            # task cancellation — otherwise it would wait for chunks forever.
+            if handle is not None:
+                handle.finish()
 
     async def _generate_audio(self, tts_engine: TTSInterface, text: str) -> str:
         """Generate audio file from text"""

--- a/src/open_llm_vtuber/conversations/tts_manager.py
+++ b/src/open_llm_vtuber/conversations/tts_manager.py
@@ -288,6 +288,12 @@ class TTSTaskManager:
 
     def clear(self) -> None:
         """Clear all pending tasks and reset state"""
+        # Cancel in-flight TTS tasks before dropping the references —
+        # otherwise a task from an interrupted turn keeps running and
+        # enqueues its (stale) payload into the replaced queue below,
+        # leaking a sentence from the previous turn into the next one.
+        for task in self.task_list:
+            task.cancel()
         self.task_list.clear()
         if self._sender_task:
             self._sender_task.cancel()

--- a/src/open_llm_vtuber/tts/tts_interface.py
+++ b/src/open_llm_vtuber/tts/tts_interface.py
@@ -6,6 +6,21 @@ from loguru import logger
 
 
 class TTSInterface(metaclass=abc.ABCMeta):
+    """
+    Interface for TTS engines.
+
+    Optional streaming protocol: an engine may additionally implement
+
+        async def async_generate_audio_streaming(self, text: str)
+
+    as an async generator yielding ``(chunk, sample_rate)`` tuples, where
+    ``chunk`` is either a ``numpy.ndarray`` of float32 samples in [-1.0, 1.0]
+    or raw little-endian int16 PCM ``bytes`` (mono). When present, the
+    conversation pipeline streams audio to the frontend chunk by chunk
+    instead of waiting for the full sentence file, reducing time-to-first-
+    audio. Engines that don't implement it keep the file-based path.
+    """
+
     async def async_generate_audio(self, text: str, file_name_no_ext=None) -> str:
         """
         Asynchronously generate speech audio file using TTS.

--- a/src/open_llm_vtuber/utils/stream_audio.py
+++ b/src/open_llm_vtuber/utils/stream_audio.py
@@ -4,6 +4,11 @@ from pydub.utils import make_chunks
 from ..agent.output_types import Actions
 from ..agent.output_types import DisplayText
 
+# Payload types for chunked TTS audio streaming. A streamed sentence is
+# delivered as one "audio-stream-start" (carrying display text/actions like
+# the legacy "audio" payload), N "audio-stream-chunk" messages of raw int16
+# PCM, and a closing "audio-stream-end".
+
 
 def _get_volume_by_chunks(audio: AudioSegment, chunk_length_ms: int) -> list:
     """
@@ -80,6 +85,67 @@ def prepare_audio_payload(
     }
 
     return payload
+
+
+def prepare_stream_start_payload(
+    stream_id: str,
+    sample_rate: int,
+    display_text: DisplayText = None,
+    actions: Actions = None,
+    forwarded: bool = False,
+) -> dict[str, any]:
+    """
+    Prepare the payload announcing a new streamed-audio sentence.
+
+    Carries the same display/action metadata as the legacy "audio" payload
+    so the frontend can show subtitles and expressions when playback starts.
+    """
+    if isinstance(display_text, DisplayText):
+        display_text = display_text.to_dict()
+
+    return {
+        "type": "audio-stream-start",
+        "stream_id": stream_id,
+        "sample_rate": sample_rate,
+        "display_text": display_text,
+        "actions": actions.to_dict() if actions else None,
+        "forwarded": forwarded,
+    }
+
+
+def prepare_stream_chunk_payload(stream_id: str, chunk) -> tuple[dict[str, any], int]:
+    """
+    Convert one TTS chunk into an "audio-stream-chunk" payload.
+
+    Accepts ``(data, sample_rate)`` where ``data`` is either raw little-endian
+    int16 PCM bytes or a numpy float32 array in [-1.0, 1.0] (mono).
+
+    Returns:
+        (payload, sample_rate)
+    """
+    data, sample_rate = chunk
+    if isinstance(data, (bytes, bytearray)):
+        pcm_bytes = bytes(data)
+    else:
+        import numpy as np
+
+        arr = np.clip(np.asarray(data, dtype=np.float32), -1.0, 1.0)
+        pcm_bytes = (arr * 32767.0).astype(np.int16).tobytes()
+
+    payload = {
+        "type": "audio-stream-chunk",
+        "stream_id": stream_id,
+        "chunk": base64.b64encode(pcm_bytes).decode("utf-8"),
+    }
+    return payload, int(sample_rate)
+
+
+def prepare_stream_end_payload(stream_id: str) -> dict[str, any]:
+    """Prepare the payload closing a streamed-audio sentence."""
+    return {
+        "type": "audio-stream-end",
+        "stream_id": stream_id,
+    }
 
 
 # Example usage:


### PR DESCRIPTION
## Summary

Today each sentence is fully synthesized into a WAV file, base64-encoded, and delivered as one monolithic `audio` WebSocket message. Playback of a sentence cannot start until its entire audio exists, so time-to-first-audio equals full-sentence synthesis time, and there is audible dead air between sentences while the next file is produced and transferred.

This PR adds a **chunked streaming path** through the existing ordered delivery pipeline. On my setup (vLLM-Omni serving Qwen3-TTS on an RTX 3080 Ti), time-to-first-audio dropped from ~2s to under 1s, and inter-sentence gaps disappeared entirely.

## How it works

**Wire protocol** — three new JSON message types over the existing WebSocket:

```
{"type":"audio-stream-start","stream_id":"<uuid>","sample_rate":24000,
 "display_text":{...},"actions":{...},"forwarded":false}
{"type":"audio-stream-chunk","stream_id":"...","chunk":"<base64 int16 PCM mono>"}  × N
{"type":"audio-stream-end","stream_id":"..."}
```

A streamed sentence occupies its sequence slot in `TTSTaskManager`'s existing ordered sender, so wire order stays strictly sequential and the frontend never sees interleaved streams. Later sentences keep synthesizing concurrently — their chunks simply buffer in their own handles until their turn, exactly like complete payloads do today.

**Engine opt-in is duck-typed.** Any engine exposing

```python
async def async_generate_audio_streaming(self, text: str)
```

(an async generator yielding `(float32 ndarray | int16 bytes, sample_rate)` tuples) gets streamed; every other engine keeps the file-based path untouched. No config changes, no factory changes, no new required interface methods — the protocol is documented in `TTSInterface`'s docstring. This keeps the PR fully backward compatible: on a stock install with no streaming-capable engine, behavior is byte-for-byte identical to today.

**Robustness details**

- The stream handle is enqueued only when the first chunk actually arrives, so the subtitle appears when audio is ready and the sample rate is known.
- Failure before the first chunk falls back to the existing silent-display payload; mid-stream failures and task cancellation always emit `audio-stream-end`, so the ordered sender can never hang.
- Silent payloads (empty TTS text) and non-streaming engines interleave correctly with streams at their sequence slots.

## Relationship to other PRs

- **Frontend counterpart** (required to hear streamed audio; link added in a comment below): implements the playback side with gapless scheduling, a deterministic jitter buffer, and Live2D lip-sync for streamed PCM. Without it, this PR is inert for streaming-capable engines only in the sense that nothing implements the protocol on `main` today — behavior stays unchanged.
- **#407 (vLLM-Omni TTS engine)**: its `TTSEngine.async_generate_audio_streaming` already satisfies this protocol, so merging both lights up streaming for vLLM-Omni with zero adapter code. #407 also now carries two measured latency optimizations (100ms client chunks; a larger initial code2wav block that eliminates the early-stream delivery deficit).

## Verification

Logic-tested with a scripted fake engine + fake websocket asserting: per-sentence wire order (start → chunks → end), two concurrently-synthesized sentences serialize by sequence number, silent payloads interleave at their slots, mid-stream exceptions still emit `audio-stream-end`, and `clear()` during an active stream doesn't hang the sender. Also verified end-to-end against a live vLLM-Omni server: stream N+1's start message goes out 0.000s after stream N's end, and chunk send pacing mirrors chunk arrival. `ruff check` and `ruff format` clean. Live-tested for several days of conversations (Spanish, Japanese, German) with streaming active — ordered delivery, interrupts, and group-unrelated flows behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming text-to-speech delivery in ordered chunks (start, chunk, end) instead of waiting for full audio.
  * Preserves strict sentence order while sending incremental audio to the frontend.
* **Bug Fixes**
  * Prevents hangs and stale updates when streaming stops early or fails before the first chunk.
  * Cancels in-flight TTS work when clearing, avoiding enqueuing leftover audio for new sessions.
* **Documentation**
  * Expanded the TTS interface description to cover the optional streaming protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->