### PR TITLE
fix: update MiniMax TTS default model

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -417,7 +417,7 @@ character_config:
       api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
       base_url: 'http://localhost:8880/v1' # TTS 服务器的基础 URL 地址
       file_extension: 'mp3' # 音频文件格式（'mp3' 或 'wav'）
-    # 详细文档见：https://platform.minimax.io/docs/api-reference/audio/text-to-audio
+    # 详细文档见：https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
     minimax_tts:
       group_id: '' # minimax 的 group_id
       api_key: '' # minimax 的 api_key

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -417,12 +417,12 @@ character_config:
       api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
       base_url: 'http://localhost:8880/v1' # TTS 服务器的基础 URL 地址
       file_extension: 'mp3' # 音频文件格式（'mp3' 或 'wav'）
-    # 详细文档见：https://platform.minimaxi.com/document/Announcement
+    # 详细文档见：https://platform.minimax.io/docs/api-reference/audio/text-to-audio
     minimax_tts:
       group_id: '' # minimax 的 group_id
       api_key: '' # minimax 的 api_key
-      # 支持的模型: 'speech-02-hd', 'speech-02-turbo'（推荐使用 'speech-02-turbo'）
-      model: 'speech-02-turbo' # minimax 模型名称
+      # 支持的模型包括: 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', 'speech-02-turbo'（推荐使用 'speech-2.8-hd'）
+      model: 'speech-2.8-hd' # minimax 模型名称
       voice_id: 'female-shaonv' # minimax 语音 id，默认 'female-shaonv'
       # 自定义发音字典，默认为空。
       # 示例: '{"tone": ["测试/(ce4)(shi4)", "危险/dangerous"]}'

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -417,12 +417,12 @@ character_config:
       api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
       base_url: 'http://localhost:8880/v1' # TTS 服务器的基础 URL 地址
       file_extension: 'mp3' # 音频文件格式（'mp3' 或 'wav'）
-    # 详细文档见：https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
+    # For more details, see: https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
     minimax_tts:
       group_id: '' # minimax 的 group_id
       api_key: '' # minimax 的 api_key
-      # 支持的模型包括: 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', 'speech-02-turbo'（推荐使用 'speech-2.8-hd'）
-      model: 'speech-2.8-hd' # minimax 模型名称
+      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      model: 'speech-2.8-hd' # MiniMax model name
       voice_id: 'female-shaonv' # minimax 语音 id，默认 'female-shaonv'
       # 自定义发音字典，默认为空。
       # 示例: '{"tone": ["测试/(ce4)(shi4)", "危险/dangerous"]}'

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -422,12 +422,12 @@ character_config:
       base_url: 'http://localhost:8880/v1' # Base URL of the TTS server
       file_extension: 'mp3' # Audio file format ('mp3' or 'wav')
 
-    # For more details, see: https://platform.minimaxi.com/document/Announcement
+    # For more details, see: https://platform.minimax.io/docs/api-reference/audio/text-to-audio
     minimax_tts:
       group_id: '' # Your minimax group_id
       api_key: '' # Your minimax api_key
-      # Supported models: 'speech-02-hd', 'speech-02-turbo' (recommended: 'speech-02-turbo')
-      model: 'speech-02-turbo' # minimax model name
+      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      model: 'speech-2.8-hd' # minimax model name
       voice_id: 'female-shaonv' # minimax voice id, default is 'female-shaonv'
       # Custom pronunciation dictionary, default empty.
       # Example: '{"tone": ["测试/(ce4)(shi4)", "危险/dangerous"]}'

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -422,7 +422,7 @@ character_config:
       base_url: 'http://localhost:8880/v1' # Base URL of the TTS server
       file_extension: 'mp3' # Audio file format ('mp3' or 'wav')
 
-    # For more details, see: https://platform.minimax.io/docs/api-reference/audio/text-to-audio
+    # For more details, see: https://platform.minimax.io/docs/api-reference/speech-t2a-http
     minimax_tts:
       group_id: '' # Your minimax group_id
       api_key: '' # Your minimax api_key

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -523,7 +523,7 @@ class MinimaxTTSConfig(I18nMixin):
 
     group_id: str = Field(..., alias="group_id")
     api_key: str = Field(..., alias="api_key")
-    model: str = Field("speech-02-turbo", alias="model")
+    model: str = Field("speech-2.8-hd", alias="model")
     voice_id: str = Field("male-qn-qingse", alias="voice_id")
     pronunciation_dict: str = Field("", alias="pronunciation_dict")
 

--- a/src/open_llm_vtuber/tts/minimax_tts.py
+++ b/src/open_llm_vtuber/tts/minimax_tts.py
@@ -9,7 +9,7 @@ class TTSEngine(TTSInterface):
         self,
         group_id: str,
         api_key: str,
-        model: str = "speech-02-turbo",
+        model: str = "speech-2.8-hd",
         voice_id: str = "male-qn-qingse",
         pronunciation_dict: str = "",
     ):

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -127,7 +127,7 @@ class TTSFactory:
             return MinimaxTTSEngine(
                 group_id=kwargs.get("group_id"),
                 api_key=kwargs.get("api_key"),
-                model=kwargs.get("model", "speech-02-turbo"),
+                model=kwargs.get("model", "speech-2.8-hd"),
                 voice_id=kwargs.get("voice_id", "male-qn-qingse"),
                 pronunciation_dict=kwargs.get("pronunciation_dict", ""),
             )


### PR DESCRIPTION
Reason: MiniMax TTS integration defaults to speech-02-turbo; refresh default to speech-2.8-hd and current docs.

## Summary
- Update MiniMax TTS code/config defaults to `speech-2.8-hd`
- Refresh English and Chinese config template docs to current MiniMax text-to-audio docs and model names

## Checks
- `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"` secret scan (no matches)
- `python3 -m compileall -q src/open_llm_vtuber/tts/minimax_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/config_manager/tts.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Default text-to-speech settings now use the newer Minimax **speech-2.8-hd** voice model (replacing the previous **speech-02-turbo** default).
  * Updated the bundled Minimax TTS configuration to reflect the **speech-2.8-\*** model lineup and recommendation.
  * When creating the Minimax TTS engine without an explicit model, it now automatically selects **speech-2.8-hd**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->