### PR TITLE
fix: update MiniMax TTS default model

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -417,12 +417,12 @@ character_config:
       api_key: 'not-needed' # 如果服务器需要，可填写 API 密钥
       base_url: 'http://localhost:8880/v1' # TTS 服务器的基础 URL 地址
       file_extension: 'mp3' # 音频文件格式（'mp3' 或 'wav'）
-    # 详细文档见：https://platform.minimaxi.com/document/Announcement
+    # For more details, see: https://platform.minimaxi.com/docs/api-reference/speech-t2a-http
     minimax_tts:
       group_id: '' # minimax 的 group_id
       api_key: '' # minimax 的 api_key
-      # 支持的模型: 'speech-02-hd', 'speech-02-turbo'（推荐使用 'speech-02-turbo'）
-      model: 'speech-02-turbo' # minimax 模型名称
+      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      model: 'speech-2.8-hd' # MiniMax model name
       voice_id: 'female-shaonv' # minimax 语音 id，默认 'female-shaonv'
       # 自定义发音字典，默认为空。
       # 示例: '{"tone": ["测试/(ce4)(shi4)", "危险/dangerous"]}'

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -421,7 +421,8 @@ character_config:
     minimax_tts:
       group_id: '' # minimax 的 group_id
       api_key: '' # minimax 的 api_key
-      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      api_url: 'https://api.minimaxi.com/v1/t2a_v2' # Speech synthesis API endpoint
+      # Recommended model: 'speech-2.8-hd'. See the documentation above for all supported models.
       model: 'speech-2.8-hd' # MiniMax model name
       voice_id: 'female-shaonv' # minimax 语音 id，默认 'female-shaonv'
       # 自定义发音字典，默认为空。

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -426,7 +426,8 @@ character_config:
     minimax_tts:
       group_id: '' # Your minimax group_id
       api_key: '' # Your minimax api_key
-      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      api_url: 'https://api.minimax.io/v1/t2a_v2' # Speech synthesis API endpoint
+      # Recommended model: 'speech-2.8-hd'. See the documentation above for all supported models.
       model: 'speech-2.8-hd' # minimax model name
       voice_id: 'female-shaonv' # minimax voice id, default is 'female-shaonv'
       # Custom pronunciation dictionary, default empty.

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -422,12 +422,12 @@ character_config:
       base_url: 'http://localhost:8880/v1' # Base URL of the TTS server
       file_extension: 'mp3' # Audio file format ('mp3' or 'wav')
 
-    # For more details, see: https://platform.minimaxi.com/document/Announcement
+    # For more details, see: https://platform.minimax.io/docs/api-reference/speech-t2a-http
     minimax_tts:
       group_id: '' # Your minimax group_id
       api_key: '' # Your minimax api_key
-      # Supported models: 'speech-02-hd', 'speech-02-turbo' (recommended: 'speech-02-turbo')
-      model: 'speech-02-turbo' # minimax model name
+      # Supported models include 'speech-2.8-hd', 'speech-2.8-turbo', 'speech-02-hd', and 'speech-02-turbo' (recommended: 'speech-2.8-hd')
+      model: 'speech-2.8-hd' # minimax model name
       voice_id: 'female-shaonv' # minimax voice id, default is 'female-shaonv'
       # Custom pronunciation dictionary, default empty.
       # Example: '{"tone": ["测试/(ce4)(shi4)", "危险/dangerous"]}'

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -523,7 +523,7 @@ class MinimaxTTSConfig(I18nMixin):
 
     group_id: str = Field(..., alias="group_id")
     api_key: str = Field(..., alias="api_key")
-    model: str = Field("speech-02-turbo", alias="model")
+    model: str = Field("speech-2.8-hd", alias="model")
     voice_id: str = Field("male-qn-qingse", alias="voice_id")
     pronunciation_dict: str = Field("", alias="pronunciation_dict")
 

--- a/src/open_llm_vtuber/config_manager/tts.py
+++ b/src/open_llm_vtuber/config_manager/tts.py
@@ -523,6 +523,7 @@ class MinimaxTTSConfig(I18nMixin):
 
     group_id: str = Field(..., alias="group_id")
     api_key: str = Field(..., alias="api_key")
+    api_url: str = Field("https://api.minimax.io/v1/t2a_v2", alias="api_url")
     model: str = Field("speech-2.8-hd", alias="model")
     voice_id: str = Field("male-qn-qingse", alias="voice_id")
     pronunciation_dict: str = Field("", alias="pronunciation_dict")
@@ -530,6 +531,9 @@ class MinimaxTTSConfig(I18nMixin):
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "group_id": Description(en="Minimax group_id", zh="Minimax 的 group_id"),
         "api_key": Description(en="Minimax API key", zh="Minimax 的 API key"),
+        "api_url": Description(
+            en="MiniMax speech API endpoint", zh="MiniMax speech API endpoint"
+        ),
         "model": Description(en="Minimax model name", zh="Minimax 模型名称"),
         "voice_id": Description(en="Minimax voice id", zh="Minimax 语音 id"),
         "pronunciation_dict": Description(

--- a/src/open_llm_vtuber/tts/minimax_tts.py
+++ b/src/open_llm_vtuber/tts/minimax_tts.py
@@ -9,12 +9,14 @@ class TTSEngine(TTSInterface):
         self,
         group_id: str,
         api_key: str,
+        api_url: str = "https://api.minimax.io/v1/t2a_v2",
         model: str = "speech-2.8-hd",
         voice_id: str = "male-qn-qingse",
         pronunciation_dict: str = "",
     ):
         self.group_id = group_id
         self.api_key = api_key
+        self.api_url = api_url
         self.model = model
         self.voice_id = voice_id
         self.pronunciation_dict = pronunciation_dict
@@ -27,7 +29,7 @@ class TTSEngine(TTSInterface):
         import json
 
         file_name = self.generate_cache_file_name(file_name_no_ext, self.file_extension)
-        url = "https://api.minimax.chat/v1/t2a_v2?GroupId=" + self.group_id
+        params = {"GroupId": self.group_id} if self.group_id else None
         headers = {
             "accept": "application/json, text/plain, */*",
             "content-type": "application/json",
@@ -66,7 +68,12 @@ class TTSEngine(TTSInterface):
 
         try:
             response = requests.request(
-                "POST", url, stream=True, headers=headers, data=json.dumps(body)
+                "POST",
+                self.api_url,
+                params=params,
+                stream=True,
+                headers=headers,
+                data=json.dumps(body),
             )
             audio = b""
             for chunk in response.raw:

--- a/src/open_llm_vtuber/tts/minimax_tts.py
+++ b/src/open_llm_vtuber/tts/minimax_tts.py
@@ -74,6 +74,7 @@ class TTSEngine(TTSInterface):
                 stream=True,
                 headers=headers,
                 data=json.dumps(body),
+                timeout=120,
             )
             audio = b""
             for chunk in response.raw:

--- a/src/open_llm_vtuber/tts/minimax_tts.py
+++ b/src/open_llm_vtuber/tts/minimax_tts.py
@@ -9,7 +9,7 @@ class TTSEngine(TTSInterface):
         self,
         group_id: str,
         api_key: str,
-        model: str = "speech-02-turbo",
+        model: str = "speech-2.8-hd",
         voice_id: str = "male-qn-qingse",
         pronunciation_dict: str = "",
     ):

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -127,7 +127,7 @@ class TTSFactory:
             return MinimaxTTSEngine(
                 group_id=kwargs.get("group_id"),
                 api_key=kwargs.get("api_key"),
-                model=kwargs.get("model", "speech-02-turbo"),
+                model=kwargs.get("model", "speech-2.8-hd"),
                 voice_id=kwargs.get("voice_id", "male-qn-qingse"),
                 pronunciation_dict=kwargs.get("pronunciation_dict", ""),
             )

--- a/src/open_llm_vtuber/tts/tts_factory.py
+++ b/src/open_llm_vtuber/tts/tts_factory.py
@@ -127,6 +127,7 @@ class TTSFactory:
             return MinimaxTTSEngine(
                 group_id=kwargs.get("group_id"),
                 api_key=kwargs.get("api_key"),
+                api_url=kwargs.get("api_url", "https://api.minimax.io/v1/t2a_v2"),
                 model=kwargs.get("model", "speech-2.8-hd"),
                 voice_id=kwargs.get("voice_id", "male-qn-qingse"),
                 pronunciation_dict=kwargs.get("pronunciation_dict", ""),


### PR DESCRIPTION
Reason: MiniMax TTS integration defaults to speech-02-turbo; refresh the default to speech-2.8-hd and use the current documentation.

## Summary
- Update MiniMax TTS code and configuration defaults to speech-2.8-hd
- Add configurable current global and China speech API endpoints while retaining optional GroupId query compatibility
- Refresh the global and China configuration template links to the current MiniMax speech HTTP documentation
- Bound synchronous MiniMax speech requests with a 120-second timeout
- Keep all modified comments in English

## Verification
- Confirmed both official documentation pages return HTTP 200 and list speech-2.8-hd with the current regional endpoints
- Verified both YAML templates, the Pydantic default, the engine request path, and the factory fallback
- Captured requests for both regional endpoints with and without the optional GroupId parameter, including the request timeout

## Checks
- `python -m compileall -q src/open_llm_vtuber/tts/minimax_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/config_manager/tts.py`
- `ruff check src/open_llm_vtuber/tts/minimax_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/config_manager/tts.py`
- `ruff format --check src/open_llm_vtuber/tts/minimax_tts.py src/open_llm_vtuber/tts/tts_factory.py src/open_llm_vtuber/config_manager/tts.py`
- Parsed both YAML configuration templates
- Validated schema defaults and captured MiniMax HTTP requests
- `git diff --check`
- Secret scan using the configured Octopatch pattern


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Minimax text-to-speech integration to use the `speech-2.8-hd` model by default.
  * Added support for configuring the Minimax speech API endpoint.
  * Improved API request handling with query parameters and a defined timeout.

* **Documentation**
  * Updated configuration guidance and API documentation links for Minimax speech synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->